### PR TITLE
🎨 Palette: Add 'Back' button navigation to interactive flows

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,7 @@
 ## 2026-04-18 - [Persona-Aware Menus & Accessibility Redundancy]
 **Learning:** For bots with distinct personas, context-aware help menus improve immersion and command discoverability. Additionally, always sending text alongside AI voice messages is a critical accessibility requirement.
 **Action:** Implement conditional help menus based on active persona state and ensure text fallbacks/companions for all media-based responses.
+
+## 2026-05-10 - [Non-Destructive Navigation]
+**Learning:** In multi-step interactive flows (like bug reporting or feedback), "Cancel" buttons are necessary but can be frustrating if the user only wants to correct a minor mistake.
+**Action:** Implement "⬅️ Back" buttons in nested sub-menus to allow users to return to the previous state without destroying their session progress.

--- a/main.py
+++ b/main.py
@@ -738,12 +738,46 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             active_menu = ALCHEMY_MENU_TEXT
         await query.edit_message_text(active_menu, parse_mode="HTML")
         return
+
+    if query.data == "ping_back":
+        ticket_states.pop(user_id, None)
+        save_state()
+        await query.answer()
+        keyboard = [
+            [InlineKeyboardButton("📝 Add Logic Comment", callback_data="ping_comment")],
+            [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")],
+            [InlineKeyboardButton("❓ Help / Tester Guide", callback_data="ping_help")]
+        ]
+        await query.edit_message_text("✅ <b>JULES SYSTEM: ONLINE.</b>", parse_mode="HTML", reply_markup=InlineKeyboardMarkup(keyboard))
+        return
+
+    if query.data == "ticket_back":
+        ticket_states[user_id] = "project"
+        ticket_data.pop(user_id, None)
+        save_state()
+        await query.answer()
+        keyboard = [
+            [InlineKeyboardButton("Clipsflow", callback_data="ticket_proj:ClipFLOW"),
+             InlineKeyboardButton("NE ≡ BU", callback_data="ticket_proj:Nebulosa")],
+            [InlineKeyboardButton("Pupbot", callback_data="ticket_proj:gemini-bot"),
+             InlineKeyboardButton("Other", callback_data="ticket_proj:Other")],
+            [InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]
+        ]
+        await query.edit_message_text(
+            "👔 <b>Jules Diagnostic Interface</b>\n<i>(Use this strictly to submit detailed, project-specific bugs.)</i>\nEntering Bug Submission Flow. (Type /cancel to abort)\n\nWhich <b>Project</b> is this bug affecting?",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
+        return
     
     if query.data == "ping_comment":
         ticket_states[user_id] = "ping_comment_entry"
         save_state()
         await query.answer()
-        keyboard = [[InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]]
+        keyboard = [
+            [InlineKeyboardButton("⬅️ Back", callback_data="ping_back"),
+             InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]
+        ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await query.edit_message_text(
             "👔 <b>Logic Feedback:</b>\nPlease type your comment about the logic. It will be logged to GitHub.",
@@ -780,7 +814,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
         keyboard = [
             [InlineKeyboardButton("📝 Add Logic Comment", callback_data="ping_comment")],
-            [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")]
+            [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")],
+            [InlineKeyboardButton("⬅️ Back", callback_data="ping_back")]
         ]
         await query.answer()
         await query.edit_message_text(help_text, parse_mode="HTML", reply_markup=InlineKeyboardMarkup(keyboard))
@@ -807,7 +842,10 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ticket_states[user_id] = "project_other"
         save_state()
         await query.answer()
-        keyboard = [[InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]]
+        keyboard = [
+            [InlineKeyboardButton("⬅️ Back", callback_data="ticket_back"),
+             InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]
+        ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await query.edit_message_text(
             "👔 <b>Manual Override</b>\nPlease type the name of the project or repository this bug belongs to:",
@@ -821,7 +859,10 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
     save_state()
     
     await query.answer()
-    keyboard = [[InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]]
+    keyboard = [
+        [InlineKeyboardButton("⬅️ Back", callback_data="ticket_back"),
+         InlineKeyboardButton("❌ Cancel", callback_data="ticket_cancel")]
+    ]
     reply_markup = InlineKeyboardMarkup(keyboard)
     safe_repo = html.escape(repo_name)
     await query.edit_message_text(


### PR DESCRIPTION
I've added "Back" buttons to the Telegram bot's interactive flows. Previously, if a user entered a sub-menu (like the logic feedback or the detailed bug description), their only exit strategy was a full cancellation. Now, they can step back to the main menu or project selection, making the interface much more forgiving and intuitive.

---
*PR created automatically by Jules for task [13217205543333505345](https://jules.google.com/task/13217205543333505345) started by @FriskyDevelopments*