### PR TITLE
🎨 Palette: Enhanced Persona Navigation and Interaction Feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,7 +31,3 @@
 ## 2026-04-23 - [Mode Exit Discoverability]
 **Learning:** In persona-driven interfaces, users may forget how to return to the default state. Explicit "Type /command to toggle off" hints in the persona-specific menus significantly reduce friction and improve user autonomy.
 **Action:** Always include exit/toggle-off instructions within the header or footer of mode-specific menus.
-
-## 2026-05-22 - [Persona Toggle Discoverability]
-**Learning:** When users enter specialized persona modes (like developer or wizard modes), they often forget the command used to enter it, making them feel "stuck" in that mode.
-**Action:** Include explicit toggle-off instructions (e.g., "Type /mode to toggle off") within the persona's help menu to ensure a clear exit path.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-15 - [Ephemeral UI & Input Guardrails]
 **Learning:** Telegram chats can quickly become cluttered with static menus and error messages. Providing a "🗑️ Close" button allows users to clean up their chat history manually. Additionally, explicit character limits in prompts reduce "Message too long" errors and manage user expectations during multi-step input flows.
 **Action:** Centralize a `CLOSE_BUTTON` pattern for all non-interactive system messages and add character limit hints (e.g., `(max N chars)`) to text-heavy input prompts.
+
+## 2026-05-22 - [Persona Toggle Discoverability]
+**Learning:** When users enter specialized persona modes (like developer or wizard modes), they often forget the command used to enter it, making them feel "stuck" in that mode.
+**Action:** Include explicit toggle-off instructions (e.g., "Type /mode to toggle off") within the persona's help menu to ensure a clear exit path.

--- a/main.py
+++ b/main.py
@@ -1309,7 +1309,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         keyboard = [
             [InlineKeyboardButton("📝 Add Logic Comment", callback_data="ping_comment")],
             [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")],
-            [InlineKeyboardButton("❓ Help / Tester Guide", callback_data="ping_help")]
+            [InlineKeyboardButton("❓ Help / Tester Guide", callback_data="ping_help")],
+            [CLOSE_BUTTON]
         ]
         await query.edit_message_text("✅ <b>JULES SYSTEM: ONLINE.</b>", parse_mode="HTML", reply_markup=InlineKeyboardMarkup(keyboard))
         return

--- a/main.py
+++ b/main.py
@@ -116,7 +116,9 @@ Available commands for developers:
 • /ticket - Report structured bugs to GitHub
 • /ping - Send logic feedback
 
-<i>Awaiting commands. Type /antigravity to toggle off.</i>"""
+<i>Awaiting commands.</i>
+
+<i>Type /antigravity to toggle off.</i>"""
 
 ALCHEMY_MENU_TEXT = """🔮 <b>STIX MΛGIC ALCHEMY</b>
 
@@ -279,20 +281,6 @@ def get_effective_mode(chat_id):
 
 def is_admin_lounge_chat(chat_id):
     return _safe_chat_id(chat_id) == _safe_chat_id(ADMIN_LOUNGE_ID)
-
-
-def get_active_menu_text(chat_id):
-    mode = get_effective_mode(chat_id)
-    # Admin Lounge defaults to Admin Assistant when no explicit persona toggle is active.
-    if mode == "puppy" and is_admin_lounge_chat(chat_id):
-        mode = "admin_assistant"
-    menu_map = {
-        "puppy": MENU_TEXT,
-        "antigravity": ANTIGRAVITY_MENU_TEXT,
-        "alchemy": ALCHEMY_MENU_TEXT,
-        "admin_assistant": ADMIN_ASSISTANT_MENU_TEXT,
-    }
-    return menu_map.get(mode, MENU_TEXT)
 
 
 def validate_link_target_chat(target_chat_id, admin_chat_id):
@@ -618,7 +606,14 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         
         if text_lower == "/menu" or text_lower == "/help" or text_lower == "/start":
             try:
-                active_menu = get_active_menu_text(chat_id)
+                active_menu = MENU_TEXT
+                effective_mode = get_effective_mode(chat_id)
+                if effective_mode == "antigravity":
+                    active_menu = ANTIGRAVITY_MENU_TEXT
+                elif effective_mode == "alchemy":
+                    active_menu = ALCHEMY_MENU_TEXT
+                elif effective_mode == "admin_assistant":
+                    active_menu = ADMIN_ASSISTANT_MENU_TEXT
                 await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e:
                 logging.error(f"Menu formatting crash: {e}")
@@ -1218,17 +1213,13 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             genai.configure(api_key=gemini_key)
             model = genai.GenerativeModel("gemini-2.5-flash", system_instruction=active_system_prompt)
             
-            try:
-                await context.bot.send_chat_action(chat_id=chat_id, action="typing")
-            except Exception as chat_action_error:
-                logging.debug(f"Ignored chat action error: {chat_action_error}")
-
             prompt_list = [prompt]
             if getattr(update.message, 'photo', None):
                 photo_file = await context.bot.get_file(update.message.photo[-1].file_id)
                 img_bytes = await photo_file.download_as_bytearray()
                 prompt_list.append({"mime_type": "image/jpeg", "data": img_bytes})
                 
+            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
             response = await model.generate_content_async(prompt_list)
             
             # Catch safety blocking
@@ -1373,7 +1364,14 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if query.data == "show_menu":
         await query.answer()
-        active_menu = get_active_menu_text(chat_id)
+        active_menu = MENU_TEXT
+        effective_mode = get_effective_mode(chat_id)
+        if effective_mode == "antigravity":
+            active_menu = ANTIGRAVITY_MENU_TEXT
+        elif effective_mode == "alchemy":
+            active_menu = ALCHEMY_MENU_TEXT
+        elif effective_mode == "admin_assistant":
+            active_menu = ADMIN_ASSISTANT_MENU_TEXT
         await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
         return
 

--- a/main.py
+++ b/main.py
@@ -268,6 +268,20 @@ def get_mode(chat_id):
     return "puppy"
 
 
+def get_active_menu_text(chat_id):
+    mode = get_mode(chat_id)
+    # Admin Lounge defaults to Admin Assistant when no explicit persona toggle is active.
+    if mode == "puppy" and _safe_chat_id(chat_id) == _safe_chat_id(ADMIN_LOUNGE_ID):
+        mode = "admin_assistant"
+    menu_map = {
+        "puppy": MENU_TEXT,
+        "antigravity": ANTIGRAVITY_MENU_TEXT,
+        "alchemy": ALCHEMY_MENU_TEXT,
+        "admin_assistant": ADMIN_ASSISTANT_MENU_TEXT,
+    }
+    return menu_map.get(mode, MENU_TEXT)
+
+
 def prevent_echo_reply(mode_name, user_text, reply_text):
     def normalize_text(value):
         return re.sub(r"[^a-z0-9]+", "", (value or "").lower())
@@ -554,13 +568,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         
         if text_lower == "/menu" or text_lower == "/help" or text_lower == "/start":
             try:
-                active_menu = MENU_TEXT
-                if chat_id in antigravity_chats:
-                    active_menu = ANTIGRAVITY_MENU_TEXT
-                elif chat_id in alchemy_chats:
-                    active_menu = ALCHEMY_MENU_TEXT
-                elif chat_id in admin_assistant_chats:
-                    active_menu = ADMIN_ASSISTANT_MENU_TEXT
+                active_menu = get_active_menu_text(chat_id)
                 await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e:
                 logging.error(f"Menu formatting crash: {e}")
@@ -1144,13 +1152,17 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             genai.configure(api_key=gemini_key)
             model = genai.GenerativeModel("gemini-2.5-flash", system_instruction=active_system_prompt)
             
+            try:
+                await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+            except Exception as chat_action_error:
+                logging.debug(f"Ignored chat action error: {chat_action_error}")
+
             prompt_list = [prompt]
             if getattr(update.message, 'photo', None):
                 photo_file = await context.bot.get_file(update.message.photo[-1].file_id)
                 img_bytes = await photo_file.download_as_bytearray()
                 prompt_list.append({"mime_type": "image/jpeg", "data": img_bytes})
                 
-            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
             response = await model.generate_content_async(prompt_list)
             
             # Catch safety blocking
@@ -1292,13 +1304,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if query.data == "show_menu":
         await query.answer()
-        active_menu = MENU_TEXT
-        if chat_id in antigravity_chats:
-            active_menu = ANTIGRAVITY_MENU_TEXT
-        elif chat_id in alchemy_chats:
-            active_menu = ALCHEMY_MENU_TEXT
-        elif chat_id in admin_assistant_chats:
-            active_menu = ADMIN_ASSISTANT_MENU_TEXT
+        active_menu = get_active_menu_text(chat_id)
         await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
         return
 
@@ -1379,7 +1385,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         keyboard = [
             [InlineKeyboardButton("📝 Add Logic Comment", callback_data="ping_comment")],
             [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")],
-            [InlineKeyboardButton("⬅️ Back", callback_data="ping_back")]
+            [InlineKeyboardButton("⬅️ Back", callback_data="ping_back")],
+            [CLOSE_BUTTON]
         ]
         await query.answer()
         await query.edit_message_text(help_text, parse_mode="HTML", reply_markup=InlineKeyboardMarkup(keyboard))

--- a/main.py
+++ b/main.py
@@ -115,20 +115,26 @@ Available commands for developers:
 • /ticket - Report structured bugs to GitHub
 • /ping - Send logic feedback
 
-<i>Awaiting commands.</i>"""
+<i>Awaiting commands.</i>
+
+<i>Type /antigravity to toggle off.</i>"""
 
 ALCHEMY_MENU_TEXT = """🔮 <b>STIX MΛGIC ALCHEMY</b>
 
 Welcome to the lab!
 • Send me viral ideas or URLs
-• Draw assets or concept art!"""
+• Draw assets or concept art!
+
+<i>Type /alchemy to toggle off.</i>"""
 
 ADMIN_ASSISTANT_MENU_TEXT = """🛠️ <b>ADMIN ASSISTANT ONLINE</b>
 
 Operational tools for Alphas:
 • Draft promos and announcements
 • Build moderation plans and workflows
-• Create step-by-step execution checklists"""
+• Create step-by-step execution checklists
+
+<i>Type /admin_assistant to toggle off.</i>"""
 
 import db
 
@@ -553,6 +559,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     active_menu = ANTIGRAVITY_MENU_TEXT
                 elif chat_id in alchemy_chats:
                     active_menu = ALCHEMY_MENU_TEXT
+                elif chat_id in admin_assistant_chats:
+                    active_menu = ADMIN_ASSISTANT_MENU_TEXT
                 await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e:
                 logging.error(f"Menu formatting crash: {e}")
@@ -851,7 +859,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 keyboard = [
                     [InlineKeyboardButton("📝 Add Logic Comment", callback_data="ping_comment")],
                     [InlineKeyboardButton("🚨 Report Bot Unresponsive", callback_data="ping_bot_dead")],
-                    [InlineKeyboardButton("❓ Help / Tester Guide", callback_data="ping_help")]
+                    [InlineKeyboardButton("❓ Help / Tester Guide", callback_data="ping_help")],
+                    [CLOSE_BUTTON]
                 ]
                 reply_markup = InlineKeyboardMarkup(keyboard)
                 try:
@@ -1141,6 +1150,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 img_bytes = await photo_file.download_as_bytearray()
                 prompt_list.append({"mime_type": "image/jpeg", "data": img_bytes})
                 
+            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
             response = await model.generate_content_async(prompt_list)
             
             # Catch safety blocking
@@ -1287,6 +1297,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             active_menu = ANTIGRAVITY_MENU_TEXT
         elif chat_id in alchemy_chats:
             active_menu = ALCHEMY_MENU_TEXT
+        elif chat_id in admin_assistant_chats:
+            active_menu = ADMIN_ASSISTANT_MENU_TEXT
         await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
         return
 


### PR DESCRIPTION
💡 What: Added toggle-off instructions to persona menus, fixed persona-aware menu navigation for the Admin Assistant, implemented a typing indicator for AI generation, and added a "Close" button to the `/ping` menu.
🎯 Why: Improves user discoverability of how to exit specialized modes, ensures consistent UI across all personas, provides immediate visual feedback during async operations, and helps keep chat history clean.
♿ Accessibility: Added clear instructional text for mode navigation and a manual cleanup option for ephemeral UI.

---
*PR created automatically by Jules for task [3274485616231806916](https://jules.google.com/task/3274485616231806916) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes: adjusts static menu text and adds a Telegram `typing` chat action before Gemini async generation, without altering core logic or data handling.
> 
> **Overview**
> Improves developer-mode UX by updating `ANTIGRAVITY_MENU_TEXT` to more clearly show the “toggle off” instruction as its own line.
> 
> Adds a Telegram `typing` indicator immediately before calling `generate_content_async`, providing interaction feedback while the bot waits for Gemini responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684e31f8724f0fce352de53cb0b6b09441ef822f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typing indicator now displays while processing AI responses, providing real-time feedback.

* **Style**
  * Reformatted menu status message into multiple lines for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->