### PR TITLE
🛡️ Sentinel: Security hardening for chat IDs and password comparison

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,7 +172,10 @@ def save_state():
 
 
 def _safe_chat_id(value):
-    return str(value) if value is not None else ""
+    s = str(value) if value is not None else ""
+    if re.match(r"^-?\d+$", s):
+        return s
+    return ""
 
 
 def _read_authorized_groups():
@@ -946,7 +949,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 
             state = ticket_states[user_id]
             if state == "antigravity_bypass":
-                if text == ANTIGRAVITY_BYPASS_PASSWORD:
+                if secrets.compare_digest(text, ANTIGRAVITY_BYPASS_PASSWORD):
                     antigravity_chats.add(chat_id)
                     if chat_id in alchemy_chats: alchemy_chats.remove(chat_id)
                     del ticket_states[user_id]

--- a/main.py
+++ b/main.py
@@ -949,7 +949,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 
             state = ticket_states[user_id]
             if state == "antigravity_bypass":
-                if secrets.compare_digest(text, ANTIGRAVITY_BYPASS_PASSWORD):
+                if secrets.compare_digest(text.encode("utf-8"), ANTIGRAVITY_BYPASS_PASSWORD.encode("utf-8")):
                     antigravity_chats.add(chat_id)
                     if chat_id in alchemy_chats: alchemy_chats.remove(chat_id)
                     del ticket_states[user_id]


### PR DESCRIPTION
This PR introduces two security hardening measures:
1. **Input Validation**: The `_safe_chat_id` function now uses a regular expression (`^-?\d+$`) to ensure that only numeric Telegram IDs are processed. This provides defense-in-depth against potential injection vulnerabilities where these IDs are used in shell commands (Doppler CLI) or appended to configuration files.
2. **Timing Attack Mitigation**: The comparison for the `ANTIGRAVITY_BYPASS_PASSWORD` has been updated to use `secrets.compare_digest`. This prevents side-channel timing attacks that could be used to leak the password.

These changes follow the principle of "Trust Nothing, Verify Everything" and "Defense in Depth".

---
*PR created automatically by Jules for task [12362930639284068421](https://jules.google.com/task/12362930639284068421) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens input validation and password comparison in access-control paths; low code churn but could impact group authorization/bypass if any IDs/password inputs are non-canonical.
> 
> **Overview**
> Hardens security checks in `main.py` by tightening `_safe_chat_id` to only accept numeric (optionally negative) Telegram IDs and returning `""` for anything else.
> 
> Updates the Antigravity bypass flow to use `secrets.compare_digest` for constant-time comparison of `ANTIGRAVITY_BYPASS_PASSWORD`, reducing timing side-channel risk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11428289e4805df72c794ed15be69a0577bfed88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened chat identifier validation to accept only numeric formats
  * Enhanced password verification security with cryptographic comparison mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->