### PR TITLE
🎨 Palette: Standardize Ephemeral UI & Input Guardrails

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,7 @@
 ## 2026-06-05 - [Unified Markup & Ephemeral Feedback]
 **Learning:** Mixing Markdown and HTML in a Telegram bot leads to parsing errors and inconsistent UI. Standardizing on HTML allows for safer escaping. Furthermore, system feedback (e.g., "User added", "Group unlinked") should always be ephemeral to avoid polluting group history.
 **Action:** Prioritize HTML parse mode for complex templates and ensure every non-conversational system response includes a 'Close' button.
+
+## 2026-06-12 - [Ephemeral Status Feedback]
+**Learning:** System messages that confirm a state change (like toggling a persona or submitting a ticket) are useful in the moment but quickly become clutter. Adding a 'Close' button to these messages empowers users to maintain a clean workspace.
+**Action:** Standardize the use of `CLOSE_KEYBOARD` for all operational success and toggle-off confirmations.

--- a/main.py
+++ b/main.py
@@ -630,7 +630,10 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 invitations[str(member.id)] = inviter_name
                 save_state()
             try:
-                keyboard = [[InlineKeyboardButton("📖 Open Menu", callback_data="show_menu")]]
+                keyboard = [
+                    [InlineKeyboardButton("📖 Open Menu", callback_data="show_menu")],
+                    [CLOSE_BUTTON]
+                ]
                 reply_markup = InlineKeyboardMarkup(keyboard)
                 await context.bot.send_message(
                     chat_id=chat_id,
@@ -754,13 +757,13 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if chat_id in admin_assistant_chats:
                 admin_assistant_chats.remove(chat_id)
                 save_state()
-                await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant OFF.</b>\nReturning to standard Pup mode.", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant OFF.</b>\nReturning to standard Pup mode.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 return
             admin_assistant_chats.add(chat_id)
             antigravity_chats.discard(chat_id)
             alchemy_chats.discard(chat_id)
             save_state()
-            await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant ONLINE.</b>\nI will now respond as your operations copilot.", parse_mode="HTML")
+            await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant ONLINE.</b>\nI will now respond as your operations copilot.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             return
 
         if text_lower.startswith("/link_group"):
@@ -888,7 +891,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 antigravity_chats.remove(chat_id)
                 save_state()
                 try:
-                    await context.bot.send_message(chat_id=chat_id, text="🔄 **Antigravity Mode Deactivated.** Returning to Pupbot persona.")
+                    await context.bot.send_message(chat_id=chat_id, text="🔄 <b>Antigravity Mode Deactivated.</b> Returning to Pupbot persona.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
                 
@@ -926,7 +929,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 alchemy_chats.remove(chat_id)
                 save_state()
                 try:
-                    await context.bot.send_message(chat_id=chat_id, text="🪄 <b>Λlchemy Curator Deactivated.</b> Returning to Pupbot persona.", parse_mode="HTML")
+                    await context.bot.send_message(chat_id=chat_id, text="🪄 <b>Λlchemy Curator Deactivated.</b> Returning to Pupbot persona.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
                 
@@ -947,14 +950,14 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 relay_chats.remove(chat_id)
                 save_state()
                 try:
-                    await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode OFF.</b> Responses will stay in this lounge.", parse_mode="HTML")
+                    await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode OFF.</b> Responses will stay in this lounge.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
             
             relay_chats.add(chat_id)
             save_state()
             try:
-                await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode ON.</b> My future text and image responses here will be forwarded directly to the Main Lounge!", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode ON.</b> My future text and image responses here will be forwarded directly to the Main Lounge!", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e: logging.debug(f"Ignored error: {e}")
             return
 
@@ -967,7 +970,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 return
             try:
                 invite = await context.bot.create_chat_invite_link(chat_id=target_chat_id, member_limit=1)
-                await context.bot.send_message(chat_id=chat_id, text=f"🎟️ <b>Exclusive Pup Lounge Link:</b>\n{invite.invite_link}\n<i>(Valid for 1 use!)</i>", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text=f"🎟️ <b>Exclusive Pup Lounge Link:</b>\n{invite.invite_link}\n<i>(Valid for 1 use!)</i>", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception:
                 logging.error("Invite link generation failed", exc_info=True)
                 try:
@@ -1172,7 +1175,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
             elif state == "project_other":
-                project = re.sub(r'[^a-zA-Z0-9._-]', '', text)
+                project = re.sub(r'[^a-zA-Z0-9._-]', '', text[:100])
                 if not project or project in (".", ".."):
                     try:
                         await context.bot.send_message(chat_id=chat_id, text="⚠️ Invalid project name. Please use alphanumeric, dots, underscores, and dashes only.")
@@ -1219,7 +1222,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 save_state()
                 try:
                     safe_project = html.escape(project)
-                    await context.bot.send_message(chat_id=chat_id, text=f"✅ <b>Ticket Submitted!</b> Antigravity has received your report and injected it into the <code>{safe_project}</code> CI/CD pipeline.", parse_mode="HTML")
+                    await context.bot.send_message(chat_id=chat_id, text=f"✅ <b>Ticket Submitted!</b> Antigravity has received your report and injected it into the <code>{safe_project}</code> CI/CD pipeline.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
 
@@ -1629,7 +1632,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await query.edit_message_text(
-            "👔 <b>Manual Override</b>\nPlease type the name of the project or repository this bug belongs to:",
+            "👔 <b>Manual Override</b>\nPlease type the name of the project or repository this bug belongs to (max 100 chars):",
             parse_mode="HTML",
             reply_markup=reply_markup
         )

--- a/main.py
+++ b/main.py
@@ -916,7 +916,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             admin_assistant_chats.discard(chat_id)
             save_state()
             try:
-                await context.bot.send_message(chat_id=chat_id, text="⚡ <b>Antigravity Interface ONLINE.</b>\nI have dropped the Pup persona. I am your developer now. What architecture are we discussing?", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text="⚡ <b>Antigravity Interface ONLINE.</b>\nI have dropped the Pup persona. I am your developer now. What architecture are we discussing?", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e: logging.debug(f"Ignored error: {e}")
             return
 
@@ -938,7 +938,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             admin_assistant_chats.discard(chat_id)
             save_state()
             try:
-                await context.bot.send_message(chat_id=chat_id, text="✨ <b>Λlchemy Curator Wizard ONLINE.</b>\nI have donned the Wizard Hat. What STIX MΛGIC features shall we conjure?", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text="✨ <b>Λlchemy Curator Wizard ONLINE.</b>\nI have donned the Wizard Hat. What STIX MΛGIC features shall we conjure?", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception as e: logging.debug(f"Ignored error: {e}")
             return
             


### PR DESCRIPTION
### 🎨 Palette: Standardize Ephemeral UI & Input Guardrails

#### 💡 What:
I have implemented several micro-UX improvements to the Telegram bot interface focused on reducing chat clutter and improving input reliability.

- **Ephemeral UI Standardization**: Added "Close" buttons (using the existing `CLOSE_BUTTON` and `CLOSE_KEYBOARD` constants) to several non-conversational system messages, including:
  - The initial welcome message.
  - Persona toggle confirmations (Admin Assistant, Alchemy, Antigravity).
  - Relay mode toggle confirmations.
  - Invite link generation success.
  - The final ticket submission confirmation.
- **Input Guardrails**: Updated the "Manual Override" project entry flow in the bug reporter:
  - Added a `(max 100 chars)` hint to the prompt.
  - Enforced this limit by truncating the input in the state handler.
- **Formatting Consistency**: Standardized the Antigravity deactivation message to use HTML instead of Markdown, ensuring consistency with the rest of the bot's UI.

#### 🎯 Why:
- **Clutter Reduction**: System status messages are useful for immediate feedback but often become "ghost" messages that clutter a user's chat history. Providing a "Close" button allows users to maintain a clean workspace.
- **Improved UX Guidance**: Explicitly stating input limits reduces user errors and manages expectations during interactive flows.
- **Accessibility**: Standardizing on HTML and providing clear dismissal options improves the overall predictability and accessibility of the interface.

#### ♿ Accessibility:
- Improved user autonomy by providing manual dismissal options for non-critical system feedback.
- Enhanced guidance for manual text input through explicit constraints.

---
*PR created automatically by Jules for task [14024751779145060869](https://jules.google.com/task/14024751779145060869) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2e246efa74ceb848f464a0971b5cde0daa430672. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a universal close button (🗑️) to bot responses for consistent keyboard cleanup.

* **Improvements**
  * “Other” project/repo input now enforces a 100-character limit before validation.
  * Confirmation and deactivation messages updated for consistent formatting and to include the close keyboard.

* **Documentation**
  * New guidance section on ephemeral status feedback and close-keyboard conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->