### PR TITLE
🎨 Palette: Improve manual project entry UX in /ticket flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1220,10 +1220,10 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
             elif state == "project_other":
-                project = re.sub(r'[^a-zA-Z0-9._-]', '', text)
+                project = re.sub(r'[^a-zA-Z0-9._-]', '', text)[:100]
                 if not project or project in (".", ".."):
                     try:
-                        await context.bot.send_message(chat_id=chat_id, text="⚠️ Invalid project name. Please use alphanumeric, dots, underscores, and dashes only.")
+                        await context.bot.send_message(chat_id=chat_id, text="⚠️ Invalid project name. Please use alphanumeric, dots, underscores, and dashes only (max 100 chars).", reply_markup=CLOSE_KEYBOARD)
                     except: pass
                     return
                 ticket_data[user_id] = {"project": project}
@@ -1886,7 +1886,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
         await query.edit_message_text(
-            "👔 <b>Manual Override</b>\nPlease type the name of the project or repository this bug belongs to:",
+            "👔 <b>Manual Override</b>\nPlease type the name of the project or repository this bug belongs to (max 100 chars).\n\n<i>Permitted: alphanumeric, dots, underscores, and dashes.</i>",
             parse_mode="HTML",
             reply_markup=reply_markup
         )


### PR DESCRIPTION
💡 What: Added character limit hints and validation feedback to the manual project entry step of the bug reporter.
🎯 Why: Users previously had no guidance on allowed characters or length, leading to confusing validation errors or potentially too-long inputs.
♿ Accessibility: Improved prompt clarity and added a dismissible error keyboard.

---
*PR created automatically by Jules for task [7447979388478995571](https://jules.google.com/task/7447979388478995571) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UX/validation tweaks to ticket project-name handling with no changes to GitHub submission logic or permissions.
> 
> **Overview**
> Improves the `/ticket` flow’s *manual project entry* by enforcing a 100-character cap after sanitization and updating the user-facing prompts to clearly state allowed characters and the max length.
> 
> On invalid manual project input, the bot now returns a clearer error message and includes the standard `CLOSE_KEYBOARD` so users can dismiss the warning easily.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1d31e6eec80b307edb21ccfaccd4c921a79727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->