### PR TITLE
🛡️ Sentinel: AI Prompt Security Hardening

### DIFF
--- a/main.py
+++ b/main.py
@@ -1393,7 +1393,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 
                 prompt = (
                     f"{SYSTEM_PROMPT}\n"
-                    f"You are currently talking to: {user_name} ({relationship}).\n"
+                    f"You are currently talking to: {identity_context} ({relationship}).\n"
                     "Never mirror the exact input; always advance the conversation.\n"
                     f"--- CONVERSATION HISTORY ---\n{history_text}\n"
                     f"--- LATEST MESSAGE ---\n"

--- a/main.py
+++ b/main.py
@@ -388,8 +388,10 @@ async def is_alpha_user(context: ContextTypes.DEFAULT_TYPE, user_id: str):
 
 
 def build_identity_context(user_name: str, user_id: str, is_alpha: bool):
+    # Sanitize user_name to prevent prompt injection or formatting breakage
+    safe_name = re.sub(r'[\r\n\[\]]', ' ', user_name or "Unknown")
     role = "Owner/Alpha (priority authority)" if is_alpha else "Lounge member"
-    return f"{user_name} ({user_id}) - {role}"
+    return f"{safe_name} ({user_id}) - {role}"
 
 
 async def _groq_text_fallback(system_prompt: str, user_text: str) -> str | None:
@@ -1319,7 +1321,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         should_reply = False
         
     if should_reply and has_text_or_photo:
-        user_text = update.message.text or update.message.caption or ""
+        # Enforce length limit to prevent resource exhaustion (DoS) via AI generation
+        user_text = (update.message.text or update.message.caption or "")[:4000]
         
         # We explicitly skip slash commands meant for logic interception above so the bot doesn't reply.
         if user_text.startswith("/") and not user_text.startswith("/pup"):

--- a/main.py
+++ b/main.py
@@ -387,9 +387,13 @@ async def is_alpha_user(context: ContextTypes.DEFAULT_TYPE, user_id: str):
     return uid in CORE_ALPHA_IDS or uid in dynamic_alpha_ids or uid in manual_alpha_ids
 
 
-def build_identity_context(user_name: str, user_id: str, is_alpha: bool):
+def sanitize_prompt_name(user_name: str):
     # Sanitize user_name to prevent prompt injection or formatting breakage
-    safe_name = re.sub(r'[\r\n\[\]]', ' ', user_name or "Unknown")
+    return re.sub(r'[\r\n\[\]]', ' ', user_name or "Unknown")
+
+
+def build_identity_context(user_name: str, user_id: str, is_alpha: bool):
+    safe_name = sanitize_prompt_name(user_name)
     role = "Owner/Alpha (priority authority)" if is_alpha else "Lounge member"
     return f"{safe_name} ({user_id}) - {role}"
 
@@ -1473,7 +1477,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 # Save to history for conversational continuity
                 if chat_id not in conversation_histories:
                     conversation_histories[chat_id] = []
-                conversation_histories[chat_id].append(f"{user_name}: {user_text}")
+                conversation_histories[chat_id].append(f"{sanitize_prompt_name(user_name)}: {user_text}")
                 conversation_histories[chat_id].append(f"Pupbot: {reply_text}")
                 # Prune to last 15 messages
                 conversation_histories[chat_id] = conversation_histories[chat_id][-15:]

--- a/main.py
+++ b/main.py
@@ -1385,15 +1385,13 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                         f"Message: {user_text}"
                     )
             else:
-                relationship = "Your ALPHA (Owner)" if is_alpha else "A lounge member"
-                
                 # Fetch history
                 history = conversation_histories.get(chat_id, [])
                 history_text = "\n".join(history[-10:]) if history else "No previous context."
                 
                 prompt = (
                     f"{SYSTEM_PROMPT}\n"
-                    f"You are currently talking to: {identity_context} ({relationship}).\n"
+                    f"You are currently talking to: {identity_context}.\n"
                     "Never mirror the exact input; always advance the conversation.\n"
                     f"--- CONVERSATION HISTORY ---\n{history_text}\n"
                     f"--- LATEST MESSAGE ---\n"

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -303,6 +303,50 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
                 result = await main._groq_text_fallback("sys", "hello")
                 self.assertIsNone(result)
 
+    async def test_default_prompt_uses_sanitized_identity_context(self):
+        message = SimpleNamespace(
+            text="hello pup",
+            caption=None,
+            photo=None,
+            new_chat_members=None,
+            message_id=10,
+            from_user=SimpleNamespace(id=123),
+            reply_to_message=None,
+            chat=SimpleNamespace(type="supergroup"),
+        )
+        update = SimpleNamespace(
+            effective_message=message,
+            effective_user=SimpleNamespace(
+                id=123,
+                first_name="Bad\n[INJECT]",
+                username="baduser",
+            ),
+            effective_chat=SimpleNamespace(id=-100),
+            message=message,
+        )
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                id=456,
+                username="PupBot",
+                send_chat_action=AsyncMock(),
+                send_message=AsyncMock(),
+            )
+        )
+        model = SimpleNamespace(
+            generate_content_async=AsyncMock(return_value=SimpleNamespace(text="safe reply"))
+        )
+
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=False)), \
+             patch("main.get_effective_mode", return_value="puppy"), \
+             patch("main.push_processed_response", new=AsyncMock()), \
+             patch("google.generativeai.configure"), \
+             patch("google.generativeai.GenerativeModel", return_value=model):
+            await main.lounge_host(update, context)
+
+        prompt = model.generate_content_async.call_args.args[0][0]
+        self.assertIn("Bad  INJECT  (123) - Lounge member", prompt)
+        self.assertNotIn("Bad\n[INJECT]", prompt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -345,6 +345,8 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
 
         prompt = model.generate_content_async.call_args.args[0][0]
         self.assertIn("Bad  INJECT  (123) - Lounge member", prompt)
+        self.assertIn("You are currently talking to: Bad  INJECT  (123) - Lounge member.", prompt)
+        self.assertNotIn("Lounge member (A lounge member)", prompt)
         self.assertNotIn("Bad\n[INJECT]", prompt)
 
 

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -304,6 +304,8 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
                 self.assertIsNone(result)
 
     async def test_default_prompt_uses_sanitized_identity_context(self):
+        original_histories = dict(main.conversation_histories)
+        main.conversation_histories.clear()
         message = SimpleNamespace(
             text="hello pup",
             caption=None,
@@ -341,13 +343,24 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
              patch("main.push_processed_response", new=AsyncMock()), \
              patch("google.generativeai.configure"), \
              patch("google.generativeai.GenerativeModel", return_value=model):
-            await main.lounge_host(update, context)
+            try:
+                await main.lounge_host(update, context)
 
-        prompt = model.generate_content_async.call_args.args[0][0]
-        self.assertIn("Bad  INJECT  (123) - Lounge member", prompt)
-        self.assertIn("You are currently talking to: Bad  INJECT  (123) - Lounge member.", prompt)
-        self.assertNotIn("Lounge member (A lounge member)", prompt)
-        self.assertNotIn("Bad\n[INJECT]", prompt)
+                prompt = model.generate_content_async.call_args.args[0][0]
+                self.assertIn("Bad  INJECT  (123) - Lounge member", prompt)
+                self.assertIn("You are currently talking to: Bad  INJECT  (123) - Lounge member.", prompt)
+                self.assertNotIn("Lounge member (A lounge member)", prompt)
+                self.assertNotIn("Bad\n[INJECT]", prompt)
+
+                message.text = "second hello pup"
+                await main.lounge_host(update, context)
+
+                second_prompt = model.generate_content_async.call_args.args[0][0]
+                self.assertIn("Bad  INJECT : hello pup", second_prompt)
+                self.assertNotIn("Bad\n[INJECT]", second_prompt)
+            finally:
+                main.conversation_histories.clear()
+                main.conversation_histories.update(original_histories)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implemented security hardening in `main.py` to protect the AI integration from prompt injection and resource exhaustion.

### 🛡️ Sentinel Security Report

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unsanitized user identity fields and unvalidated input lengths in AI prompts.
🎯 **Impact:** 
- **Prompt Injection:** Malicious users could use specially crafted usernames (containing newlines or control characters) to manipulate the LLM's system prompt.
- **Resource Exhaustion (DoS):** Extremely large inputs could cause high latency, excessive token consumption, or crashes in the AI processing pipeline.
🔧 **Fix:** 
- Added regex-based sanitization for `user_name` in `build_identity_context`.
- Added strict slicing to `user_text` (4000 chars) in the message handler.
✅ **Verification:** 
- Syntax verified with `py_compile`.
- Logic verified with a targeted test suite mocking external dependencies.

---
*PR created automatically by Jules for task [7980333584975347236](https://jules.google.com/task/7980333584975347236) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core message-to-LLM prompt path; sanitization or truncation bugs could change bot behavior or degrade response quality. However the changes are small, localized, and covered by a focused unit test.
> 
> **Overview**
> Adds prompt-hardening in `main.py` by sanitizing user display names before embedding them into LLM prompts/history (blocking newlines/brackets) and by capping incoming `user_text` to 4000 characters to reduce resource-exhaustion risk.
> 
> Also simplifies the default-mode prompt to use the standardized `identity_context` string, and adds an async test ensuring sanitized identity context is used in prompts and conversation history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e60b42d24b8f8e4da77e108f8606c033cdec7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->