### PR TITLE
🎨 Palette: Fix Alpha Console crash & Navigation UX

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,6 +157,7 @@ jules_chats = set(db.get_val("jules_chats", []))
 antigravity_chats = set(db.get_val("antigravity_chats", []))
 alchemy_chats = set(db.get_val("alchemy_chats", []))
 admin_assistant_chats = set(db.get_val("admin_assistant_chats", []))
+dashboard_chats = set(db.get_val("dashboard_chats", []))
 relay_chats = set(db.get_val("relay_chats", []))
 debuggers = set(db.get_val("debuggers", [ALPHA]))
 ticket_states = dict(db.get_val("ticket_states", {}))
@@ -183,6 +184,7 @@ def save_state():
     db.set_val("antigravity_chats", list(antigravity_chats))
     db.set_val("alchemy_chats", list(alchemy_chats))
     db.set_val("admin_assistant_chats", list(admin_assistant_chats))
+    db.set_val("dashboard_chats", list(dashboard_chats))
     db.set_val("relay_chats", list(relay_chats))
     db.set_val("debuggers", list(debuggers))
     db.set_val("ticket_states", ticket_states)
@@ -1850,15 +1852,25 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if query.data == "manage_auth":
         raw_groups = os.getenv("AUTHORIZED_GROUPS", "")
         auth_groups = [g.strip() for g in raw_groups.split(",") if g.strip()]
-        group_list = "\n".join([f"• `{g}`" for g in auth_groups]) if auth_groups else "None"
+        group_list = "\n".join([f"• <code>{g}</code>" for g in auth_groups]) if auth_groups else "None"
         await query.answer()
-        await query.edit_message_text(f"⚙️ <b>Authorized Groups</b>\n\n{group_list}\n\n<i>(Use /authorize_group in a chat to add it, or remove from Doppler to revoke)</i>", parse_mode="HTML")
+        keyboard = [[InlineKeyboardButton("⬅️ Back", callback_data="cmd:dashboard"), CLOSE_BUTTON]]
+        await query.edit_message_text(
+            f"⚙️ <b>Authorized Groups</b>\n\n{group_list}\n\n<i>(Use /authorize_group in a chat to add it, or remove from Doppler to revoke)</i>",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
         return
 
     if query.data == "manage_debug":
-        debug_list = "\n".join([f"• `{d}`" for d in debuggers]) if debuggers else "None"
+        debug_list = "\n".join([f"• <code>{d}</code>" for d in debuggers]) if debuggers else "None"
         await query.answer()
-        await query.edit_message_text(f"👨‍💻 <b>Authorized Debuggers</b>\n\n{debug_list}\n\n<i>(Use /add_debugger <id> to add more)</i>", parse_mode="HTML")
+        keyboard = [[InlineKeyboardButton("⬅️ Back", callback_data="cmd:dashboard"), CLOSE_BUTTON]]
+        await query.edit_message_text(
+            f"👨‍💻 <b>Authorized Debuggers</b>\n\n{debug_list}\n\n<i>(Use /add_debugger &lt;id&gt; to add more)</i>",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(keyboard)
+        )
         return
 
     if query.data == "toggle_sleep":


### PR DESCRIPTION
This PR addresses a critical `NameError` crash in the Alpha Console and improves the management interface's navigation.

### 💡 What:
1. **Crash Fix**: Initialized `dashboard_chats` from the database and added it to the `save_state` persistence logic. This prevents the bot from crashing when rendering the Alpha Console's "DASHBOARD" status.
2. **Navigation Enhancement**: Added "⬅️ Back" buttons to the `manage_auth` (Authorized Groups) and `manage_debug` (Authorized Debuggers) sub-menus, allowing admins to return to the main Dashboard without re-triggering commands.
3. **UI Polish**: Standardized sub-menu formatting to use semantic `<code>` tags for IDs and escaped HTML entities (e.g., `<id>` to `&lt;id&gt;`) to ensure robust rendering in Telegram.

### 🎯 Why:
- The missing `dashboard_chats` variable caused an immediate crash for any Alpha user trying to access `/dashboard` or `/pupsona`.
- The management sub-menus were "UX traps" with no clear way to return to the previous view, violating core navigation principles.

### ♿ Accessibility & UX:
- Improved keyboard accessibility by providing a clear path back to the parent menu.
- Enhanced visual clarity for technical identifiers using standard monospace formatting.

---
*PR created automatically by Jules for task [15191552996636804921](https://jules.google.com/task/15191552996636804921) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds missing `dashboard_chats` state initialization/persistence and minor Telegram UI formatting/navigation tweaks, with no auth or data model changes beyond storing one additional key.
> 
> **Overview**
> Fixes an Alpha Console crash by initializing `dashboard_chats` from the DB and persisting it in `save_state()`.
> 
> Improves admin dashboard sub-menu UX by adding a **Back** button (returning to `cmd:dashboard`) for the `manage_auth` and `manage_debug` views, and standardizes Telegram HTML rendering by switching ID formatting to `<code>` and escaping `&lt;id&gt;` in instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 206187103119522948a2737c1407dd9588648098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->