### PR TITLE
🛡️ Sentinel: Harden admin commands, AI metadata, and error handling

### DIFF
--- a/gemini_agent.py
+++ b/gemini_agent.py
@@ -10,8 +10,8 @@ model = genai.GenerativeModel('gemini-1.5-flash')
 def run_cmd(cmd):
     try:
         return subprocess.check_output(shlex.split(cmd), shell=False, text=True, stderr=subprocess.STDOUT)
-    except Exception as e:
-        return f"Error: {str(e)}"
+    except Exception:
+        return "Error: Command execution failed."
 
 def audit_project():
     print("🔍 Fase 1: Escaneando ClipFLOW (Mty Edition)...")

--- a/main.py
+++ b/main.py
@@ -388,8 +388,11 @@ async def is_alpha_user(context: ContextTypes.DEFAULT_TYPE, user_id: str):
 
 
 def build_identity_context(user_name: str, user_id: str, is_alpha: bool):
+    # Sanitize user_name to prevent prompt injection or formatting breakage
+    safe_name = (user_name or "Unknown")[:100]
+    safe_name = safe_name.replace("\n", " ").replace("\r", " ").replace("[", " ").replace("]", " ")
     role = "Owner/Alpha (priority authority)" if is_alpha else "Lounge member"
-    return f"{user_name} ({user_id}) - {role}"
+    return f"{safe_name} ({user_id}) - {role}"
 
 
 async def _groq_text_fallback(system_prompt: str, user_text: str) -> str | None:
@@ -706,11 +709,17 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if is_alpha:
                 parts = text.split()
                 if len(parts) > 1:
-                    debuggers.add(parts[1])
-                    save_state()
-                    try:
-                         await context.bot.send_message(chat_id=chat_id, text=f"✅ User {parts[1]} added to debuggers list.", reply_markup=CLOSE_KEYBOARD)
-                    except Exception as e: logging.debug(f"Ignored error: {e}")
+                    user_to_add = parts[1]
+                    if re.match(r"^\d+$", user_to_add):
+                        debuggers.add(user_to_add)
+                        save_state()
+                        try:
+                             await context.bot.send_message(chat_id=chat_id, text=f"✅ User <code>{html.escape(user_to_add)}</code> added to debuggers list.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
+                        except Exception as e: logging.debug(f"Ignored error: {e}")
+                    else:
+                        try:
+                             await context.bot.send_message(chat_id=chat_id, text="⚠️ Invalid User ID. Please provide a numeric Telegram ID.", reply_markup=CLOSE_KEYBOARD)
+                        except Exception as e: logging.debug(f"Ignored error: {e}")
                 else:
                     try:
                          await context.bot.send_message(chat_id=chat_id, text="Usage: /add_debugger <user_id>", reply_markup=CLOSE_KEYBOARD)
@@ -722,11 +731,17 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             if is_alpha:
                 parts = text.split()
                 if len(parts) > 1:
-                    manual_alpha_ids.add(parts[1])
-                    save_state()
-                    try:
-                         await context.bot.send_message(chat_id=chat_id, text=f"✅ User {parts[1]} has been granted Alpha Admin rights.", reply_markup=CLOSE_KEYBOARD)
-                    except Exception as e: logging.debug(f"Ignored error: {e}")
+                    user_to_add = parts[1]
+                    if re.match(r"^\d+$", user_to_add):
+                        manual_alpha_ids.add(user_to_add)
+                        save_state()
+                        try:
+                             await context.bot.send_message(chat_id=chat_id, text=f"✅ User <code>{html.escape(user_to_add)}</code> has been granted Alpha Admin rights.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
+                        except Exception as e: logging.debug(f"Ignored error: {e}")
+                    else:
+                        try:
+                             await context.bot.send_message(chat_id=chat_id, text="⚠️ Invalid User ID. Please provide a numeric Telegram ID.", reply_markup=CLOSE_KEYBOARD)
+                        except Exception as e: logging.debug(f"Ignored error: {e}")
                 else:
                     try:
                          await context.bot.send_message(chat_id=chat_id, text="Usage: /add_admin <user_id>", reply_markup=CLOSE_KEYBOARD)


### PR DESCRIPTION
🚨 Severity: MEDIUM/ENHANCEMENT
💡 Vulnerability: Multiple security and stability issues identified in main.py and gemini_agent.py:
1. Lack of input validation on `/add_debugger` and `/add_admin` commands allowed non-numeric or malicious strings to be added to privileged authorization sets.
2. Unsanitized user names in `build_identity_context` created a risk of prompt injection and formatting breakage in AI-driven features.
3. Information leakage in `gemini_agent.py` where raw command execution errors were returned to the caller.

🎯 Impact: Malformed authorization data, potential AI prompt manipulation, and exposure of internal system/path details.
🔧 Fix: 
- Implemented strict numeric validation (r"^\d+$") and HTML escaping for admin commands.
- Added truncation (100 chars) and newline/bracket removal to `build_identity_context`.
- Replaced raw exception strings in `run_cmd` with a generic error message ("Error: Command execution failed.").
✅ Verification: Syntax verified with `py_compile`. Manual code review confirmed implementation of validation and sanitization logic. Existing test suite attempted (failed due to missing sandbox dependencies requests/flask).

---
*PR created automatically by Jules for task [14665144885826433587](https://jules.google.com/task/14665144885826433587) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privileged command paths and identity metadata used in AI prompts; low complexity but mistakes could lock out admins or break moderation workflows.
> 
> **Overview**
> Hardens privileged Telegram commands by requiring numeric IDs for `/add_debugger` and `/add_admin`, and safely echoing the ID back using HTML escaping.
> 
> Sanitizes `build_identity_context` to truncate and strip newline/bracket characters from user names to reduce prompt-injection/formatting issues in AI-facing metadata.
> 
> Redacts command execution exception details in `gemini_agent.py` by returning a generic failure message instead of raw error strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610e1dc3b2b4a13f7a1ebf1febbcf97e03569ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->