### PR TITLE
🎨 Palette: Ephemeral System Feedback & Visual Progress

### DIFF
--- a/main.py
+++ b/main.py
@@ -1120,6 +1120,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     system_instruction="You are a master vaporwave copywriter. Only output valid JSON.",
                     generation_config=genai.types.GenerationConfig(response_mime_type="application/json")
                 )
+                await context.bot.send_chat_action(chat_id=chat_id, action="typing")
                 response = await model.generate_content_async(promo_prompt)
                 promo_data = json.loads(response.text)
                 
@@ -1168,7 +1169,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                     logging.error("DM matrix failed", exc_info=True)
                     dm_status = "⚠️ DM matrix dispatch failed."
 
-                await context.bot.send_message(chat_id=chat_id, text=f"🚀 <b>Omni-Channel Blast Complete!</b>\n\n{html.escape(twitter_status)}\n{html.escape(dm_status)}", parse_mode="HTML")
+                await context.bot.send_message(chat_id=chat_id, text=f"🚀 <b>Omni-Channel Blast Complete!</b>\n\n{html.escape(twitter_status)}\n{html.escape(dm_status)}", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
             except Exception:
                 logging.error("Promo generation failed", exc_info=True)
                 try:
@@ -1184,7 +1185,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 ticket_data.pop(user_id, None)
                 save_state()
                 try:
-                    await context.bot.send_message(chat_id=chat_id, text="🛑 Ticketing flow aborted.")
+                    await context.bot.send_message(chat_id=chat_id, text="🛑 Ticketing flow aborted.", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.debug(f"Ignored error: {e}")
                 return
                 
@@ -1193,7 +1194,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 if update.message.chat.type != "private":
                     try:
                         await update.message.delete()
-                        await context.bot.send_message(chat_id=chat_id, text="⛔ <b>Security Alert:</b> Never enter bypass passwords in communal chats. Password entry must be done in Private DM.", parse_mode="HTML")
+                        await context.bot.send_message(chat_id=chat_id, text="⛔ <b>Security Alert:</b> Never enter bypass passwords in communal chats. Password entry must be done in Private DM.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                     except: pass
                     return
 


### PR DESCRIPTION
### 🎨 Palette: Ephemeral System Feedback & Visual Progress

This PR implements two micro-UX enhancements aimed at improving the bot's responsiveness and minimizing chat clutter.

#### 💡 What:
1.  **Visual Progress:** Added `await context.bot.send_chat_action(chat_id=chat_id, action="typing")` to the `/promo` command immediately before calling the Gemini API.
2.  **Ephemeral UI Cleanup:** Integrated `reply_markup=CLOSE_KEYBOARD` into three additional system messages in `main.py`:
    *   The "Omni-Channel Blast Complete" report.
    *   The "Ticketing flow aborted" confirmation message.
    *   The "Security Alert" warning about bypass password entries in communal chats.

#### 🎯 Why:
-   **Responsiveness:** AI generation can take several seconds. Without a typing indicator, the bot appears unresponsive after a `/promo` command.
-   **Clutter Reduction:** As identified in the project's UX journal, static system messages often "pollute" group histories. Providing a "Close" button allows users to manually clean up the interface once they've read the notification.

#### ♿ Accessibility & UX:
-   Provides immediate visual feedback for long-running operations.
-   Empowers users to manage their own chat space by providing explicit dismissal controls for non-interactive system feedback.

Verified with `python3 -m py_compile main.py` and manual code inspection.

---
*PR created automatically by Jules for task [737850207648134231](https://jules.google.com/task/737850207648134231) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only changes: adds a typing indicator before the Gemini `/promo` call and attaches `CLOSE_KEYBOARD` to a few additional bot status messages, without altering business logic or data handling.
> 
> **Overview**
> Improves bot micro-UX by showing a `typing` chat action during `/promo` generation to make long-running AI calls feel responsive.
> 
> Adds `reply_markup=CLOSE_KEYBOARD` to more system/status messages (promo completion, ticket cancel, and communal bypass-password warning) so users can dismiss them and reduce chat clutter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5549ae8cdb1090c79d6b659389f8b61f7cb3c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->