### PR TITLE
🛡️ Sentinel: Harden Alpha Authorization and refactor Group Authorization logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ sleep_mode = db.get_val("sleep_mode", False)
 relay_drafts = {}
 conversation_histories = {}
 
-CORE_ALPHA_IDS = {str(ALPHA), *{str(uid) for uid in EXTRA_ALPHAS}}
+CORE_ALPHA_IDS = {str(uid) for uid in ([ALPHA] + EXTRA_ALPHAS) if str(uid).strip()}
 LINK_CODE_TTL_SECONDS = int(os.getenv("LINK_CODE_TTL_SECONDS", "900"))
 ADMIN_OWNER_REFRESH_SECONDS = int(os.getenv("ADMIN_OWNER_REFRESH_SECONDS", "300"))
 admin_owner_last_refresh = 0.0
@@ -225,8 +225,17 @@ def _write_authorized_groups(authorized_groups):
         return True
     except Exception:
         try:
-            with open(env_path, "a") as f:
-                f.write(f"\nAUTHORIZED_GROUPS={new_list_str}\n")
+            lines = []
+            if os.path.exists(env_path):
+                with open(env_path, "r") as f:
+                    lines = f.readlines()
+
+            # Remove existing AUTHORIZED_GROUPS entries
+            new_lines = [line for line in lines if not line.startswith("AUTHORIZED_GROUPS=")]
+            new_lines.append(f"AUTHORIZED_GROUPS={new_list_str}\n")
+
+            with open(env_path, "w") as f:
+                f.writelines(new_lines)
             return True
         except Exception:
             return False
@@ -383,6 +392,8 @@ async def refresh_dynamic_alpha_ids(context: ContextTypes.DEFAULT_TYPE):
 
 async def is_alpha_user(context: ContextTypes.DEFAULT_TYPE, user_id: str):
     uid = _safe_chat_id(user_id)
+    if not uid:
+        return False
     if uid in CORE_ALPHA_IDS or uid in dynamic_alpha_ids or uid in manual_alpha_ids:
         return True
     await refresh_dynamic_alpha_ids(context)
@@ -1632,32 +1643,15 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
         
-        raw_groups = os.getenv("AUTHORIZED_GROUPS", "")
-        authorized_groups = [g.strip() for g in raw_groups.split(",") if g.strip()]
-        
-        if chat_id in authorized_groups:
+        if chat_id in _read_authorized_groups():
             await query.answer("🐶 This group is already authorized!", show_alert=True)
             return
             
-        new_groups = authorized_groups + [chat_id]
-        new_list_str = ",".join(new_groups)
-        env_path = os.path.join(os.path.dirname(__file__), ".env")
-        doppler_cli = "/opt/homebrew/bin/doppler" if os.path.exists("/opt/homebrew/bin/doppler") else "doppler"
-        doppler_project = "geminipup"
-        
-        try:
-            subprocess.run([doppler_cli, "secrets", "set", f"AUTHORIZED_GROUPS={new_list_str}", "-p", doppler_project, "-c", "dev"], check=True)
+        if _authorize_group_local(chat_id):
             await query.answer("✅ GROUP AUTHORIZED!", show_alert=True)
             await context.bot.send_message(chat_id=chat_id, text="✅ <b>GROUP AUTHORIZED!</b>\nAnyone inside this group now has permission to talk to me! Arf!", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
-        except Exception as e:
-            try:
-                with open(env_path, "a") as f:
-                    f.write(f"\nAUTHORIZED_GROUPS={new_list_str}\n")
-                await query.answer("✅ GROUP AUTHORIZED (Local)", show_alert=True)
-                await context.bot.send_message(chat_id=chat_id, text="✅ <b>GROUP AUTHORIZED!</b>\nAnyone inside this group now has permission to talk to me! Arf!\n<i>(Local fallback saved)</i>", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
-            except Exception as e2:
-                logging.error("Failed to save authorized group permanently", exc_info=True)
-                await context.bot.send_message(chat_id=chat_id, text="⚠️ Added to memory, but failed to save permanently.")
+        else:
+            await query.answer("⚠️ Failed to authorize.", show_alert=True)
         return
 
     if query.data == "cmd:antigravity":


### PR DESCRIPTION
This PR implements security hardening for Alpha Admin authorization and refactors the group authorization logic to be more secure and maintainable.

Key changes:
1. **Alpha Authorization:** Prevents potential bypasses by ensuring `CORE_ALPHA_IDS` does not contain empty strings and adding strict early-exit guards in `is_alpha_user`.
2. **Group Authorization:** Unifies the authorization flow across the bot by using centralized helper functions.
3. **Persistence Hardening:** The `.env` fallback for saving authorized groups now replaces existing entries instead of appending, preventing resource exhaustion and configuration corruption over time.

These changes follow the principle of 'Defense in Depth' and ensure more robust access control.

---
*PR created automatically by Jules for task [15020457289314090104](https://jules.google.com/task/15020457289314090104) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin/alpha authorization and group access control flows; small but security-sensitive changes could unintentionally lock out valid admins or fail to persist authorizations if env/Doppler handling differs across environments.
> 
> **Overview**
> Hardens *alpha/admin authorization* by filtering empty IDs out of `CORE_ALPHA_IDS` and adding an early guard in `is_alpha_user` to reject invalid/non-numeric user IDs.
> 
> Refactors *group authorization* to use the shared `_read_authorized_groups`/`_authorize_group_local` helpers from the callback flow, and hardens persistence by rewriting `.env` to replace any existing `AUTHORIZED_GROUPS=` entries instead of repeatedly appending them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b530a3aeb0edd1ca735f9639c46c07bd65178b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->