### PR TITLE
🛡️ Sentinel: Harden Group Authorization & Persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -39,3 +39,8 @@
 **Vulnerability:** Raw exception details were still being leaked in multiple handlers (UI, promo status, fallback persistence, and AI engine) despite previous fixes.
 **Learning:** Hardening against information leakage must be exhaustive. Status reports (like promo success/failure) often escape standard error handling and can inadvertently expose backend failures to end-users.
 **Prevention:** Audit all 'except' blocks for 'f-string' interpolation of exceptions in 'send_message' calls. Standardize on generic "Internal error" messages for users while using 'logging.error(..., exc_info=True)' for full context in logs.
+
+## 2026-05-09 - Idempotent Configuration Persistence
+**Vulnerability:** The group authorization fallback in `main.py` appended new `AUTHORIZED_GROUPS` entries to the `.env` file without removing old ones, leading to file bloat and potential resource exhaustion.
+**Learning:** Fallback persistence mechanisms for configuration must be idempotent. Simple append-only strategies can cause degradation over time or accidental configuration corruption.
+**Prevention:** Always implement a read-modify-write pattern for configuration updates to ensure only one instance of a key exists, preserving the file's integrity and preventing resource leaks.

--- a/main.py
+++ b/main.py
@@ -225,8 +225,27 @@ def _write_authorized_groups(authorized_groups):
         return True
     except Exception:
         try:
-            with open(env_path, "a") as f:
-                f.write(f"\nAUTHORIZED_GROUPS={new_list_str}\n")
+            lines = []
+            if os.path.exists(env_path):
+                with open(env_path, "r") as f:
+                    lines = f.readlines()
+
+            new_lines = []
+            found = False
+            for line in lines:
+                if line.strip().startswith("AUTHORIZED_GROUPS="):
+                    new_lines.append(f"AUTHORIZED_GROUPS={new_list_str}\n")
+                    found = True
+                else:
+                    new_lines.append(line)
+
+            if not found:
+                if new_lines and not new_lines[-1].endswith("\n"):
+                    new_lines.append("\n")
+                new_lines.append(f"AUTHORIZED_GROUPS={new_list_str}\n")
+
+            with open(env_path, "w") as f:
+                f.writelines(new_lines)
             return True
         except Exception:
             return False
@@ -1631,33 +1650,21 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if not await is_alpha_user(context, user_id):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
-        
-        raw_groups = os.getenv("AUTHORIZED_GROUPS", "")
-        authorized_groups = [g.strip() for g in raw_groups.split(",") if g.strip()]
-        
-        if chat_id in authorized_groups:
+
+        if chat_id in _read_authorized_groups():
             await query.answer("🐶 This group is already authorized!", show_alert=True)
             return
-            
-        new_groups = authorized_groups + [chat_id]
-        new_list_str = ",".join(new_groups)
-        env_path = os.path.join(os.path.dirname(__file__), ".env")
-        doppler_cli = "/opt/homebrew/bin/doppler" if os.path.exists("/opt/homebrew/bin/doppler") else "doppler"
-        doppler_project = "geminipup"
-        
-        try:
-            subprocess.run([doppler_cli, "secrets", "set", f"AUTHORIZED_GROUPS={new_list_str}", "-p", doppler_project, "-c", "dev"], check=True)
+
+        if _authorize_group_local(chat_id):
             await query.answer("✅ GROUP AUTHORIZED!", show_alert=True)
-            await context.bot.send_message(chat_id=chat_id, text="✅ <b>GROUP AUTHORIZED!</b>\nAnyone inside this group now has permission to talk to me! Arf!", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
-        except Exception as e:
-            try:
-                with open(env_path, "a") as f:
-                    f.write(f"\nAUTHORIZED_GROUPS={new_list_str}\n")
-                await query.answer("✅ GROUP AUTHORIZED (Local)", show_alert=True)
-                await context.bot.send_message(chat_id=chat_id, text="✅ <b>GROUP AUTHORIZED!</b>\nAnyone inside this group now has permission to talk to me! Arf!\n<i>(Local fallback saved)</i>", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
-            except Exception as e2:
-                logging.error("Failed to save authorized group permanently", exc_info=True)
-                await context.bot.send_message(chat_id=chat_id, text="⚠️ Added to memory, but failed to save permanently.")
+            await context.bot.send_message(
+                chat_id=chat_id,
+                text="✅ <b>GROUP AUTHORIZED!</b>\nAnyone inside this group now has permission to talk to me! Arf!",
+                parse_mode="HTML",
+                reply_markup=CLOSE_KEYBOARD
+            )
+        else:
+            await query.answer("⚠️ Failed to save authorization.", show_alert=True)
         return
 
     if query.data == "cmd:antigravity":


### PR DESCRIPTION
Hardened the group authorization logic and configuration persistence in `main.py`. Refactored the callback handler to use unified helpers and implemented idempotent updates for the `.env` fallback to prevent resource exhaustion.

---
*PR created automatically by Jules for task [3814820188752546920](https://jules.google.com/task/3814820188752546920) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches group authorization/persistence logic and changes how `AUTHORIZED_GROUPS` is written to Doppler/.env, which could inadvertently break authorization if edge cases occur. Scope is contained but impacts access control behavior and config durability.
> 
> **Overview**
> **Hardens group authorization persistence** by making updates to `AUTHORIZED_GROUPS` idempotent instead of append-only when falling back to writing `.env`, preventing unbounded file growth.
> 
> **Refactors the `cmd:authorize_group` callback** to rely on the shared `_read_authorized_groups()`/`_authorize_group_local()` helpers, removing duplicated parsing and simplifying success/failure messaging.
> 
> Adds a new Sentinel journal entry documenting the idempotent config persistence issue and prevention guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b5a55d5b347ae3817d9c6709eaee6264e025d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->