### PR TITLE
🛡️ Sentinel: [HIGH] Harden Alpha auth and conversational input limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The group authorization fallback in `main.py` appended new `AUTHORIZED_GROUPS` entries to the `.env` file without removing old ones, leading to file bloat and potential resource exhaustion.
 **Learning:** Fallback persistence mechanisms for configuration must be idempotent. Simple append-only strategies can cause degradation over time or accidental configuration corruption.
 **Prevention:** Always implement a read-modify-write pattern for configuration updates to ensure only one instance of a key exists, preserving the file's integrity and preventing resource leaks.
+
+## 2026-05-10 - Hardening Auth Sets & Input Limits
+**Vulnerability:** Authorization sets (like `CORE_ALPHA_IDS`) could contain empty strings due to loose initialization, potentially allowing auth bypasses if user IDs were not strictly validated. Conversational inputs lacked length limits, posing a resource exhaustion risk.
+**Learning:** Hardening security sets requires type-safe initialization; using `.strip()` on unvalidated inputs from `.env` or `os.getenv` can cause crashes (AttributeError) if values are unexpectedly non-string types (e.g., integers). Early-exit guards in auth helpers are essential for defense-in-depth.
+**Prevention:** Use list comprehensions with explicit type casting and filtering: `{str(uid).strip() for uid in [...] if str(uid).strip()}`. Always add early-exit guards to auth functions (e.g., `if not uid: return False`) and enforce application-level truncation for all user-provided text.

--- a/main.py
+++ b/main.py
@@ -171,7 +171,7 @@ sleep_mode = db.get_val("sleep_mode", False)
 relay_drafts = {}
 conversation_histories = {}
 
-CORE_ALPHA_IDS = {str(ALPHA), *{str(uid) for uid in EXTRA_ALPHAS}}
+CORE_ALPHA_IDS = {str(uid).strip() for uid in [ALPHA, *EXTRA_ALPHAS] if str(uid).strip()}
 LINK_CODE_TTL_SECONDS = int(os.getenv("LINK_CODE_TTL_SECONDS", "900"))
 ADMIN_OWNER_REFRESH_SECONDS = int(os.getenv("ADMIN_OWNER_REFRESH_SECONDS", "300"))
 admin_owner_last_refresh = 0.0
@@ -438,6 +438,8 @@ async def refresh_dynamic_alpha_ids(context: ContextTypes.DEFAULT_TYPE):
 
 async def is_alpha_user(context: ContextTypes.DEFAULT_TYPE, user_id: str):
     uid = _safe_chat_id(user_id)
+    if not uid:
+        return False
     if uid in CORE_ALPHA_IDS or uid in dynamic_alpha_ids or uid in manual_alpha_ids:
         return True
     await refresh_dynamic_alpha_ids(context)
@@ -1345,7 +1347,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         should_reply = False
         
     if should_reply and has_text_or_photo:
-        user_text = update.message.text or update.message.caption or ""
+        user_text = (update.message.text or update.message.caption or "")[:4000]
         
         # We explicitly skip slash commands meant for logic interception above so the bot doesn't reply.
         if user_text.startswith("/") and not user_text.startswith("/pup"):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Loose authorization set initialization and missing length limits on conversational inputs.
🎯 Impact: Potential authorization bypasses if IDs are improperly handled and resource exhaustion (DoS) from excessively long messages.
🔧 Fix:
- Hardened CORE_ALPHA_IDS initialization with type-safe filtering of empty strings: `{str(uid).strip() for uid in [ALPHA, *EXTRA_ALPHAS] if str(uid).strip()}`.
- Added an early-exit guard in `is_alpha_user` to return `False` immediately if the sanitized user ID is empty.
- Enforced a 4000-character limit on `user_text` in the `lounge_host` handler to protect backend resources.
✅ Verification: Verified via manual logic testing (simulated in `test_sentinel_fixes.py`) and syntax verification of `main.py`. Existing tests skipped due to missing environment dependencies.

---
*PR created automatically by Jules for task [12486325123220277046](https://jules.google.com/task/12486325123220277046) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization checks and user-input handling; small, targeted changes but mistakes here could affect access control or message processing behavior.
> 
> **Overview**
> **Security hardening for alpha authorization and chat input handling.**
> 
> `CORE_ALPHA_IDS` is now built via type-cast + `.strip()` + empty-filtering to avoid accidental empty-string entries, and `is_alpha_user` now early-returns `False` when `_safe_chat_id` yields an empty ID.
> 
> Conversational `user_text` is truncated to 4000 chars in `lounge_host` to limit resource usage from excessively long messages. The Sentinel journal is updated to document these learnings and prevention guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d15b27f1df022f77bde8c6da7b1b9493c3279243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->