### PR TITLE
🛡️ Sentinel: [MEDIUM] Add authorization check for manual GitHub AI reviews

### DIFF
--- a/github_bot.py
+++ b/github_bot.py
@@ -140,13 +140,20 @@ def github_webhook():
     # 2. Listen for manual trigger via comments (@pupbot or /pupbot)
     elif event == "issue_comment" and payload.get("action") == "created":
         comment_body = payload["comment"]["body"].lower()
-        if ("@pupbot review" in comment_body or "/pupbot" in comment_body or "/review" in comment_body or "@gemini" in comment_body or "gemini" in comment_body) and "pull_request" in payload["issue"]:
+        # Security: Only allow manual triggers from trusted members to prevent quota abuse.
+        # Allowed associations: OWNER, MEMBER, COLLABORATOR.
+        author_association = payload["comment"].get("author_association", "NONE")
+        is_trusted = author_association in ("OWNER", "MEMBER", "COLLABORATOR")
+
+        if is_trusted and ("@pupbot review" in comment_body or "/pupbot" in comment_body or "/review" in comment_body or "@gemini" in comment_body or "gemini" in comment_body) and "pull_request" in payload["issue"]:
             pr_number = payload["issue"]["number"]
             repo_full_name = payload["repository"]["full_name"]
             pr_api_url = payload["issue"]["pull_request"]["url"]
             print(f"Manual Codepup review triggered via comment on PR #{pr_number}")
             # For PR API URLs, we must send the V3 diff accept header
             perform_review(pr_number, pr_api_url, repo_full_name, use_api_header=True)
+        elif not is_trusted and any(trigger in comment_body for trigger in ["@pupbot", "/pupbot", "/review", "@gemini"]):
+            print(f"Unauthorized trigger attempt by {payload['sender']['login']} (Association: {author_association})")
 
     return jsonify({"status": "ok"})
 

--- a/test_security.py
+++ b/test_security.py
@@ -63,5 +63,39 @@ class TestSecurity(unittest.TestCase):
         self.assertFalse(perform_review(1, 'https://github.com/foo/bar', 'foo/bar/baz'))
         self.assertFalse(perform_review(1, 'https://github.com/foo/bar', '../../etc/passwd'))
 
+    def test_manual_trigger_authorization(self):
+        from unittest.mock import patch
+
+        payload_base = {
+            'action': 'created',
+            'issue': {'number': 1, 'pull_request': {'url': 'https://api.github.com/repos/foo/bar/pulls/1'}},
+            'repository': {'full_name': 'foo/bar'},
+            'sender': {'login': 'testuser'}
+        }
+
+        # 1. Test unauthorized (NONE)
+        payload_unauth = payload_base.copy()
+        payload_unauth['comment'] = {'body': '@pupbot review', 'author_association': 'NONE'}
+        payload_unauth_json = json.dumps(payload_unauth)
+        sig_unauth = 'sha256=' + hmac.new(b'test_secret', msg=payload_unauth_json.encode('utf-8'), digestmod=hashlib.sha256).hexdigest()
+
+        with patch('github_bot.perform_review') as mocked_perform:
+            headers = {'X-Hub-Signature-256': sig_unauth, 'X-GitHub-Event': 'issue_comment'}
+            resp = self.app.post('/github-webhook', data=payload_unauth_json, headers=headers, content_type='application/json')
+            self.assertEqual(resp.status_code, 200)
+            mocked_perform.assert_not_called()
+
+        # 2. Test authorized (OWNER)
+        payload_auth = payload_base.copy()
+        payload_auth['comment'] = {'body': '@pupbot review', 'author_association': 'OWNER'}
+        payload_auth_json = json.dumps(payload_auth)
+        sig_auth = 'sha256=' + hmac.new(b'test_secret', msg=payload_auth_json.encode('utf-8'), digestmod=hashlib.sha256).hexdigest()
+
+        with patch('github_bot.perform_review') as mocked_perform:
+            headers = {'X-Hub-Signature-256': sig_auth, 'X-GitHub-Event': 'issue_comment'}
+            resp = self.app.post('/github-webhook', data=payload_auth_json, headers=headers, content_type='application/json')
+            self.assertEqual(resp.status_code, 200)
+            mocked_perform.assert_called_once()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Identified a security gap in `github_bot.py` where manual AI code review triggers via issue comments (e.g., `@pupbot review`) were not authorized, allowing any GitHub user to consume the bot's Gemini API quota.

Implemented a check against the `author_association` field in the webhook payload, restricting these triggers to trusted repository members (`OWNER`, `MEMBER`, `COLLABORATOR`). Added corresponding test cases in `test_security.py` to verify the fix.

---
*PR created automatically by Jules for task [14919261350895205866](https://jules.google.com/task/14919261350895205866) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds authorization gating to the comment-triggered review path; risk is moderate because it changes webhook behavior and could block legitimate manual triggers if GitHub payloads differ (e.g., missing/incorrect `author_association`).
> 
> **Overview**
> Prevents untrusted users from triggering manual AI reviews via PR comments by requiring `comment.author_association` to be one of `OWNER`, `MEMBER`, or `COLLABORATOR` before calling `perform_review`.
> 
> Adds a security regression test covering both unauthorized (no review triggered) and authorized (review triggered) comment payloads, and logs unauthorized trigger attempts for visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4a71ddccd27d1e8b4205edf9b50e428b56e9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->