### PR TITLE
🛡️ Sentinel: [HIGH] Fix unauthorized manual review trigger in GitHub bot

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The group authorization fallback in `main.py` appended new `AUTHORIZED_GROUPS` entries to the `.env` file without removing old ones, leading to file bloat and potential resource exhaustion.
 **Learning:** Fallback persistence mechanisms for configuration must be idempotent. Simple append-only strategies can cause degradation over time or accidental configuration corruption.
 **Prevention:** Always implement a read-modify-write pattern for configuration updates to ensure only one instance of a key exists, preserving the file's integrity and preventing resource leaks.
+
+## 2026-05-16 - Unauthorized Manual AI Review Triggers
+**Vulnerability:** The GitHub bot allowed any user to trigger an AI-powered manual code review via keywords in issue comments, regardless of their association with the repository.
+**Learning:** Event-driven automation that consumes external API quotas (like Gemini) must enforce strict authorization checks on the event actor, even for seemingly "public" interactions like comments.
+**Prevention:** Always validate the `author_association` (or similar permission field) in webhook payloads before executing resource-intensive operations. Restrict triggers to 'OWNER', 'MEMBER', or 'COLLABORATOR' by default.

--- a/github_bot.py
+++ b/github_bot.py
@@ -141,6 +141,12 @@ def github_webhook():
     elif event == "issue_comment" and payload.get("action") == "created":
         comment_body = payload["comment"]["body"].lower()
         if ("@pupbot review" in comment_body or "/pupbot" in comment_body or "/review" in comment_body or "@gemini" in comment_body or "gemini" in comment_body) and "pull_request" in payload["issue"]:
+            # Security: Only allow OWNER, MEMBER, or COLLABORATOR to trigger manual reviews
+            author_assoc = payload.get("comment", {}).get("author_association")
+            if author_assoc not in ("OWNER", "MEMBER", "COLLABORATOR"):
+                print(f"Blocked unauthorized manual review trigger from association: {author_assoc}")
+                return jsonify({"status": "denied", "reason": "unauthorized"}), 200
+
             pr_number = payload["issue"]["number"]
             repo_full_name = payload["repository"]["full_name"]
             pr_api_url = payload["issue"]["pull_request"]["url"]

--- a/test_security.py
+++ b/test_security.py
@@ -63,5 +63,39 @@ class TestSecurity(unittest.TestCase):
         self.assertFalse(perform_review(1, 'https://github.com/foo/bar', 'foo/bar/baz'))
         self.assertFalse(perform_review(1, 'https://github.com/foo/bar', '../../etc/passwd'))
 
+    def test_webhook_manual_review_authorization(self):
+        import github_bot
+        from unittest.mock import patch
+
+        # Payload for manual review trigger
+        payload_dict = {
+            'action': 'created',
+            'issue': {'number': 1, 'pull_request': {'url': 'https://api.github.com/repos/foo/bar/pulls/1'}},
+            'comment': {'body': '@pupbot review', 'author_association': 'NONE'},
+            'repository': {'full_name': 'foo/bar'}
+        }
+
+        def send_payload(p):
+            p_json = json.dumps(p)
+            sig = 'sha256=' + hmac.new(b'test_secret', msg=p_json.encode('utf-8'), digestmod=hashlib.sha256).hexdigest()
+            headers = {'X-Hub-Signature-256': sig, 'X-GitHub-Event': 'issue_comment'}
+            return self.app.post('/github-webhook', data=p_json, headers=headers, content_type='application/json')
+
+        with patch('github_bot.perform_review') as mocked_review:
+            # 1. Unauthorized user (NONE)
+            resp = send_payload(payload_dict)
+            self.assertEqual(resp.status_code, 200)
+            data = json.loads(resp.data)
+            self.assertEqual(data['status'], 'denied')
+            self.assertFalse(mocked_review.called)
+
+            # 2. Authorized user (MEMBER)
+            payload_dict['comment']['author_association'] = 'MEMBER'
+            resp = send_payload(payload_dict)
+            self.assertEqual(resp.status_code, 200)
+            data = json.loads(resp.data)
+            self.assertEqual(data['status'], 'ok')
+            self.assertTrue(mocked_review.called)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Restricts manual AI code reviews triggered via issue comments to users with OWNER, MEMBER, or COLLABORATOR associations to prevent unauthorized resource consumption.

---
*PR created automatically by Jules for task [16836860893904238975](https://jules.google.com/task/16836860893904238975) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes webhook behavior for `issue_comment` events and could block legitimate manual review triggers if GitHub `author_association` values differ from expectations.
> 
> **Overview**
> Prevents unauthorized users from triggering AI-powered manual PR reviews via issue comments by enforcing an `author_association` allowlist (`OWNER`, `MEMBER`, `COLLABORATOR`) before calling `perform_review`.
> 
> Adds a security regression test covering both denied and allowed manual-trigger scenarios, and records the incident/prevention guidance in `.jules/sentinel.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4849fa9bb71bc308091057598fcb7d85b091137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->