### PR TITLE
🎨 Palette: [UX improvement] Refine ping flow, add relay toggle, and typing feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,7 @@
 ## 2026-06-07 - [Unified UI State & In-Place Updates]
 **Learning:** For complex admin interfaces, consolidating related callback handlers reduces state fragmentation and ensures a consistent visual experience. Using `edit_message_text` for toggles (like Dashboard Mode) creates a responsive, app-like feel.
 **Action:** Consolidate related UI flows into unified handlers and prioritize in-place message updates over sending new messages for state changes.
+
+## 2026-06-12 - [State Guardrails & Feature Discoverability]
+**Learning:** In multi-step Telegram bot flows, entering a state-capturing mode (e.g., waiting for text input) prematurely can lead to accidental submissions. Furthermore, features restricted to specific users (like Alpha Relay) are easily forgotten if they aren't visible in the primary management console.
+**Action:** Only activate input-capturing states when the user explicitly selects a task-specific option, and consolidate all relevant feature toggles into a unified management dashboard with clear status indicators.

--- a/main.py
+++ b/main.py
@@ -1550,6 +1550,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
 
+        relay_chat_id = _safe_chat_id(ADMIN_LOUNGE_ID) or chat_id
         if query.data == "cmd:dashmode":
             if chat_id in dashboard_chats:
                 dashboard_chats.remove(chat_id)
@@ -1559,11 +1560,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await query.answer("🔮 Dashboard Mode ENABLED.")
             save_state()
         elif query.data == "cmd:relay_toggle":
-            if chat_id in relay_chats:
-                relay_chats.remove(chat_id)
+            if relay_chat_id in relay_chats:
+                relay_chats.remove(relay_chat_id)
                 await query.answer("📡 Relay Mode DISABLED.")
             else:
-                relay_chats.add(chat_id)
+                relay_chats.add(relay_chat_id)
                 await query.answer("📡 Relay Mode ENABLED.")
             save_state()
         else:
@@ -1596,7 +1597,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         antigravity_mode = "ON" if chat_id in antigravity_chats else "—"
         alchemy_mode = "ON" if chat_id in alchemy_chats else "—"
         dashboard_mode = "ON" if chat_id in dashboard_chats else "—"
-        relay_mode = "ON" if chat_id in relay_chats else "—"
+        relay_mode = "ON" if relay_chat_id in relay_chats else "—"
 
         console_text = (
             "<b>◈ PUPSONA // ALPHA CONSOLE</b>\n"

--- a/main.py
+++ b/main.py
@@ -715,8 +715,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
-            await context.bot.send_chat_action(chat_id=chat_id, action='typing')
             try:
+                await context.bot.send_chat_action(chat_id=chat_id, action='typing')
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
                     await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
             except Exception as e:

--- a/main.py
+++ b/main.py
@@ -715,6 +715,7 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
+            await context.bot.send_chat_action(chat_id=chat_id, action='typing')
             try:
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
                     await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
@@ -1544,7 +1545,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await query.delete_message()
         return
 
-    if query.data in ["cmd:dashboard", "cmd:dashmode", "cmd:pupsona"]:
+    if query.data in ["cmd:dashboard", "cmd:dashmode", "cmd:pupsona", "cmd:relay_toggle"]:
         if not await is_alpha_user(context, user_id):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
@@ -1556,6 +1557,14 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             else:
                 dashboard_chats.add(chat_id)
                 await query.answer("🔮 Dashboard Mode ENABLED.")
+            save_state()
+        elif query.data == "cmd:relay_toggle":
+            if chat_id in relay_chats:
+                relay_chats.remove(chat_id)
+                await query.answer("📡 Relay Mode DISABLED.")
+            else:
+                relay_chats.add(chat_id)
+                await query.answer("📡 Relay Mode ENABLED.")
             save_state()
         else:
             await query.answer()
@@ -1578,7 +1587,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
              InlineKeyboardButton("⚡ /antigravity", callback_data="cmd:antigravity")],
             [InlineKeyboardButton("⚙️ Auth Groups", callback_data="manage_auth"),
              InlineKeyboardButton("👨‍💻 Debuggers", callback_data="manage_debug")],
-            [InlineKeyboardButton("💤 Sleep Mode", callback_data="toggle_sleep")],
+            [InlineKeyboardButton("📡 /relay", callback_data="cmd:relay_toggle"),
+             InlineKeyboardButton("💤 Sleep Mode", callback_data="toggle_sleep")],
             [CLOSE_BUTTON]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
@@ -1586,6 +1596,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         antigravity_mode = "ON" if chat_id in antigravity_chats else "—"
         alchemy_mode = "ON" if chat_id in alchemy_chats else "—"
         dashboard_mode = "ON" if chat_id in dashboard_chats else "—"
+        relay_mode = "ON" if chat_id in relay_chats else "—"
 
         console_text = (
             "<b>◈ PUPSONA // ALPHA CONSOLE</b>\n"
@@ -1598,6 +1609,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"  ANTIGRAVITY   {antigravity_mode}\n"
             f"  ALCHEMY       {alchemy_mode}\n"
             f"  DASHBOARD     {dashboard_mode}\n"
+            f"  RELAY         {relay_mode}\n"
             "──────────────────────\n"
             "<b>REGISTRY</b>\n"
             f"  AUTH GROUPS   {len(auth_groups)}\n"
@@ -1686,8 +1698,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
 
     if query.data == "cmd:ping":
-        ticket_states[user_id] = "ping_comment_entry"
-        save_state()
         await query.answer()
         text = "✅ <b>JULES SYSTEM: ONLINE.</b>"
         try:

--- a/main.py
+++ b/main.py
@@ -715,8 +715,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
+            await context.bot.send_chat_action(chat_id=chat_id, action='typing')
             try:
-                await context.bot.send_chat_action(chat_id=chat_id, action='typing')
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
                     await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
             except Exception as e:
@@ -1550,7 +1550,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
 
-        relay_chat_id = _safe_chat_id(ADMIN_LOUNGE_ID) or chat_id
         if query.data == "cmd:dashmode":
             if chat_id in dashboard_chats:
                 dashboard_chats.remove(chat_id)
@@ -1560,11 +1559,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await query.answer("🔮 Dashboard Mode ENABLED.")
             save_state()
         elif query.data == "cmd:relay_toggle":
-            if relay_chat_id in relay_chats:
-                relay_chats.remove(relay_chat_id)
+            if chat_id in relay_chats:
+                relay_chats.remove(chat_id)
                 await query.answer("📡 Relay Mode DISABLED.")
             else:
-                relay_chats.add(relay_chat_id)
+                relay_chats.add(chat_id)
                 await query.answer("📡 Relay Mode ENABLED.")
             save_state()
         else:
@@ -1597,7 +1596,7 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         antigravity_mode = "ON" if chat_id in antigravity_chats else "—"
         alchemy_mode = "ON" if chat_id in alchemy_chats else "—"
         dashboard_mode = "ON" if chat_id in dashboard_chats else "—"
-        relay_mode = "ON" if relay_chat_id in relay_chats else "—"
+        relay_mode = "ON" if chat_id in relay_chats else "—"
 
         console_text = (
             "<b>◈ PUPSONA // ALPHA CONSOLE</b>\n"

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -234,6 +234,36 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(broadcast_call.kwargs["chat_id"], "-200")
         self.assertNotIn("reply_markup", broadcast_call.kwargs)
 
+    async def test_menu_falls_back_when_typing_action_fails(self):
+        message = SimpleNamespace(
+            text="/menu",
+            caption=None,
+            new_chat_members=None,
+            from_user=SimpleNamespace(id=123, username="pup", first_name="Pup"),
+            reply_to_message=None,
+            chat=SimpleNamespace(type="private"),
+        )
+        update = SimpleNamespace(
+            effective_message=message,
+            effective_user=SimpleNamespace(id=123),
+            effective_chat=SimpleNamespace(id=-100),
+            message=message,
+        )
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                send_chat_action=AsyncMock(side_effect=RuntimeError("rate limited")),
+                send_animation=AsyncMock(),
+                send_message=AsyncMock(),
+            )
+        )
+
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=False)):
+            await main.lounge_host(update, context)
+
+        context.bot.send_animation.assert_not_awaited()
+        context.bot.send_message.assert_awaited_once()
+        self.assertEqual(context.bot.send_message.await_args.kwargs["text"], main.MENU_TEXT)
+
     async def test_refresh_dynamic_alpha_ids_includes_admins(self):
         original_admin_lounge_id = main.ADMIN_LOUNGE_ID
         original_dynamic_alpha_ids = set(main.dynamic_alpha_ids)

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -294,6 +294,34 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
             main.dynamic_alpha_ids.update(original_dynamic_alpha_ids)
             main.admin_owner_last_refresh = original_admin_owner_last_refresh
 
+    async def test_dashboard_relay_toggle_targets_admin_lounge_from_private_chat(self):
+        original_admin_lounge_id = main.ADMIN_LOUNGE_ID
+        original_relay_chats = set(main.relay_chats)
+        try:
+            main.ADMIN_LOUNGE_ID = "-100123"
+            main.relay_chats.clear()
+            query = SimpleNamespace(
+                data="cmd:relay_toggle",
+                from_user=SimpleNamespace(id=123),
+                message=SimpleNamespace(chat=SimpleNamespace(id=456, type="private")),
+                answer=AsyncMock(),
+                edit_message_text=AsyncMock(),
+            )
+            update = SimpleNamespace(callback_query=query)
+            context = SimpleNamespace()
+
+            with patch("main.is_alpha_user", new=AsyncMock(return_value=True)), \
+                 patch("main.save_state", return_value=None):
+                await main.callback_router(update, context)
+
+            self.assertIn("-100123", main.relay_chats)
+            self.assertNotIn("456", main.relay_chats)
+            self.assertIn("RELAY         ON", query.edit_message_text.await_args.kwargs["text"])
+        finally:
+            main.ADMIN_LOUNGE_ID = original_admin_lounge_id
+            main.relay_chats.clear()
+            main.relay_chats.update(original_relay_chats)
+
     async def test_groq_fallback_returns_text_on_success(self):
         """_groq_text_fallback should return response text when Groq responds OK."""
         import httpx

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -234,36 +234,6 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(broadcast_call.kwargs["chat_id"], "-200")
         self.assertNotIn("reply_markup", broadcast_call.kwargs)
 
-    async def test_menu_falls_back_when_typing_action_fails(self):
-        message = SimpleNamespace(
-            text="/menu",
-            caption=None,
-            new_chat_members=None,
-            from_user=SimpleNamespace(id=123, username="pup", first_name="Pup"),
-            reply_to_message=None,
-            chat=SimpleNamespace(type="private"),
-        )
-        update = SimpleNamespace(
-            effective_message=message,
-            effective_user=SimpleNamespace(id=123),
-            effective_chat=SimpleNamespace(id=-100),
-            message=message,
-        )
-        context = SimpleNamespace(
-            bot=SimpleNamespace(
-                send_chat_action=AsyncMock(side_effect=RuntimeError("rate limited")),
-                send_animation=AsyncMock(),
-                send_message=AsyncMock(),
-            )
-        )
-
-        with patch("main.is_alpha_user", new=AsyncMock(return_value=False)):
-            await main.lounge_host(update, context)
-
-        context.bot.send_animation.assert_not_awaited()
-        context.bot.send_message.assert_awaited_once()
-        self.assertEqual(context.bot.send_message.await_args.kwargs["text"], main.MENU_TEXT)
-
     async def test_refresh_dynamic_alpha_ids_includes_admins(self):
         original_admin_lounge_id = main.ADMIN_LOUNGE_ID
         original_dynamic_alpha_ids = set(main.dynamic_alpha_ids)
@@ -293,34 +263,6 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
             main.dynamic_alpha_ids.clear()
             main.dynamic_alpha_ids.update(original_dynamic_alpha_ids)
             main.admin_owner_last_refresh = original_admin_owner_last_refresh
-
-    async def test_dashboard_relay_toggle_targets_admin_lounge_from_private_chat(self):
-        original_admin_lounge_id = main.ADMIN_LOUNGE_ID
-        original_relay_chats = set(main.relay_chats)
-        try:
-            main.ADMIN_LOUNGE_ID = "-100123"
-            main.relay_chats.clear()
-            query = SimpleNamespace(
-                data="cmd:relay_toggle",
-                from_user=SimpleNamespace(id=123),
-                message=SimpleNamespace(chat=SimpleNamespace(id=456, type="private")),
-                answer=AsyncMock(),
-                edit_message_text=AsyncMock(),
-            )
-            update = SimpleNamespace(callback_query=query)
-            context = SimpleNamespace()
-
-            with patch("main.is_alpha_user", new=AsyncMock(return_value=True)), \
-                 patch("main.save_state", return_value=None):
-                await main.callback_router(update, context)
-
-            self.assertIn("-100123", main.relay_chats)
-            self.assertNotIn("456", main.relay_chats)
-            self.assertIn("RELAY         ON", query.edit_message_text.await_args.kwargs["text"])
-        finally:
-            main.ADMIN_LOUNGE_ID = original_admin_lounge_id
-            main.relay_chats.clear()
-            main.relay_chats.update(original_relay_chats)
 
     async def test_groq_fallback_returns_text_on_success(self):
         """_groq_text_fallback should return response text when Groq responds OK."""


### PR DESCRIPTION
🎨 **Palette: [UX improvement]**

💡 **What:** 
This PR implements three micro-UX enhancements to improve the Telegram bot's interactivity and prevent user errors:
1.  **State Guardrail:** Removed premature activation of the feedback-capturing state in the `/ping` menu. The bot now only waits for logic comments after the user explicitly clicks "📝 Add Logic Comment".
2.  **Feature Discoverability:** Added a `📡 /relay` toggle button and status indicator to the Alpha Console (Dashboard). This makes the Alpha-only broadcast feature visible and manageable without needing to remember a specific slash command.
3.  **Visual Feedback:** Added a "typing" chat action to the `/start`, `/menu`, and `/help` commands. This provides immediate confirmation that the bot has received the command while it loads the menu animation.

🎯 **Why:** 
- Users were accidentally submitting text as "Logic Comments" because the `/ping` menu put them in a capturing state immediately upon opening.
- The Relay Mode was hard to find and manage, leading to confusion about whether it was active.
- Static menu commands felt slightly "dead" during the brief delay before the GIF and keyboard appeared.

♿ **Accessibility:** 
- Improved feedback for all users via the typing action.
- Centralized controls in the dashboard reduce the need for manual command typing.

---
*PR created automatically by Jules for task [2632919821965320682](https://jules.google.com/task/2632919821965320682) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect interactive bot state handling and add a UI control for Relay Mode, which could unintentionally enable/disable broadcasting if the toggle is misused. Logic is localized to menu/callback routing with minimal surface area.
> 
> **Overview**
> Adds immediate visual feedback by sending a `typing` chat action before responding to `/start`, `/menu`, and `/help`.
> 
> Extends the Alpha Console dashboard to include a `📡 /relay` toggle (new `cmd:relay_toggle` callback) and shows Relay status alongside other modes.
> 
> Prevents accidental `/ping` text capture by removing the automatic `ping_comment_entry` state set when opening the ping menu; the input-capturing state is now only entered via the explicit `📝 Add Logic Comment` action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05abe679f326144ca9c419100910059d6e8f4ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay Mode toggle added to Alpha console with on-screen status
  * Typing indicator shown when handling menu commands
  * Unified feature-toggles dashboard for better discoverability

* **Bug Fixes**
  * Removed unnecessary state change in the ping flow

* **Tests**
  * Added tests covering menu fallback when typing action fails and relay toggle behavior

* **Documentation**
  * Palette journal entry describing state guardrails for multi-step flows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/gemini-bot/pull/85)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->