### PR TITLE
🛡️ Sentinel: [HIGH] Restrict GitHub manual reviews to authorized users

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -44,3 +44,8 @@
 **Vulnerability:** The group authorization fallback in `main.py` appended new `AUTHORIZED_GROUPS` entries to the `.env` file without removing old ones, leading to file bloat and potential resource exhaustion.
 **Learning:** Fallback persistence mechanisms for configuration must be idempotent. Simple append-only strategies can cause degradation over time or accidental configuration corruption.
 **Prevention:** Always implement a read-modify-write pattern for configuration updates to ensure only one instance of a key exists, preserving the file's integrity and preventing resource leaks.
+
+## 2026-05-16 - GitHub Bot Authorization & Trigger Hardening
+**Vulnerability:** The GitHub webhook bot triggered expensive AI code reviews for any pull request event or comment containing broad keywords (like 'gemini'), regardless of the user's authorization status.
+**Learning:** Webhooks that trigger external API calls (especially LLMs) must verify the requester's identity or relationship to the project via `author_association` or similar metadata to prevent resource exhaustion and unauthorized access. broad keyword matching in communal contexts (issue comments) leads to accidental triggers.
+**Prevention:** Restrict webhook-triggered actions to trusted roles (e.g., `OWNER`, `MEMBER`, `COLLABORATOR`). Use specific command prefixes or mentions for manual triggers instead of generic substring matches.

--- a/github_bot.py
+++ b/github_bot.py
@@ -10,6 +10,7 @@ import google.generativeai as genai
 app = Flask(__name__)
 
 GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET")
+ALLOWED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
 def verify_signature(data, signature):
     """Verify that the payload was sent from GitHub by validating SHA256."""
@@ -130,6 +131,11 @@ def github_webhook():
 
     # 1. Listen for new PRs or changes to a PR
     if event == "pull_request" and payload.get("action") in ["opened", "synchronize"]:
+        author_assoc = payload.get("pull_request", {}).get("author_association")
+        if author_assoc not in ALLOWED_ASSOCIATIONS:
+            print(f"Denying automated review: user association '{author_assoc}' not in {ALLOWED_ASSOCIATIONS}")
+            return jsonify({"status": "denied", "reason": "unauthorized"}), 200
+
         pr = payload["pull_request"]
         diff_url = pr["diff_url"]
         repo_full_name = payload["repository"]["full_name"]
@@ -139,8 +145,14 @@ def github_webhook():
 
     # 2. Listen for manual trigger via comments (@pupbot or /pupbot)
     elif event == "issue_comment" and payload.get("action") == "created":
+        author_assoc = payload.get("comment", {}).get("author_association")
+        if author_assoc not in ALLOWED_ASSOCIATIONS:
+            print(f"Denying manual review: user association '{author_assoc}' not in {ALLOWED_ASSOCIATIONS}")
+            return jsonify({"status": "denied", "reason": "unauthorized"}), 200
+
         comment_body = payload["comment"]["body"].lower()
-        if ("@pupbot review" in comment_body or "/pupbot" in comment_body or "/review" in comment_body or "@gemini" in comment_body or "gemini" in comment_body) and "pull_request" in payload["issue"]:
+        # Tighten keyword matching: removed generic 'gemini' substring match
+        if ("@pupbot review" in comment_body or "/pupbot" in comment_body or "/review" in comment_body or "@gemini" in comment_body) and "pull_request" in payload["issue"]:
             pr_number = payload["issue"]["number"]
             repo_full_name = payload["repository"]["full_name"]
             pr_api_url = payload["issue"]["pull_request"]["url"]


### PR DESCRIPTION
### 🚨 Severity: HIGH

### 💡 Vulnerability:
The GitHub webhook bot (`github_bot.py`) was triggering Gemini-powered AI code reviews for any Pull Request or issue comment containing certain keywords (like "gemini"), regardless of who initiated the action. This allowed unauthorized external users to consume the bot's AI quota and potentially spam repository PRs.

### 🎯 Impact:
Unauthorized resource (Gemini API quota) consumption and potential for repository noise/spam.

### 🔧 Fix:
- Introduced `ALLOWED_ASSOCIATIONS` set containing "OWNER", "MEMBER", and "COLLABORATOR".
- Updated the `pull_request` and `issue_comment` webhook handlers to verify the `author_association` of the user.
- Unauthorized requests now receive a `200 OK` response with a JSON payload indicating the denial, preventing retries while stopping the execution.
- Tightened keyword matching for manual triggers by removing the broad "gemini" substring match and requiring more specific patterns (e.g., "@gemini").

### ✅ Verification:
Verified with a new test suite (mocked external dependencies) that:
1. Unauthorized users (association "CONTRIBUTOR" or "NONE") are denied.
2. Authorized users (association "OWNER" or "MEMBER") are allowed.
3. Broad keywords like "i love gemini" no longer trigger reviews, while "@gemini review" does.
4. Syntax check passed via `python3 -m py_compile github_bot.py`.

---
*PR created automatically by Jules for task [8946139254457598987](https://jules.google.com/task/8946139254457598987) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds authorization gates on webhook-triggered AI reviews; a mistake could block legitimate review triggers or allow unexpected bypass via payload shape changes.
> 
> **Overview**
> Prevents the GitHub webhook bot from running expensive AI reviews unless the requester is a trusted GitHub user association (`OWNER`, `MEMBER`, `COLLABORATOR`) for both PR-open/sync events and comment-triggered reviews.
> 
> Tightens manual trigger parsing by removing the generic `"gemini"` substring match, requiring explicit commands/mentions, and documents the new hardening in `.jules/sentinel.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cadbcc79dae96db13189cf9a390b9a2bff4d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->