### PR TITLE
Fix typing indicator timing and resiliency in AI flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -1213,13 +1213,17 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
             genai.configure(api_key=gemini_key)
             model = genai.GenerativeModel("gemini-2.5-flash", system_instruction=active_system_prompt)
             
+            try:
+                await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+            except Exception as chat_action_error:
+                logging.debug(f"Ignored chat action error: {chat_action_error}")
+
             prompt_list = [prompt]
             if getattr(update.message, 'photo', None):
                 photo_file = await context.bot.get_file(update.message.photo[-1].file_id)
                 img_bytes = await photo_file.download_as_bytearray()
                 prompt_list.append({"mime_type": "image/jpeg", "data": img_bytes})
                 
-            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
             response = await model.generate_content_async(prompt_list)
             
             # Catch safety blocking


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- send Telegram `typing` chat action before any photo download/generation work in `lounge_host`
- wrap `send_chat_action` in local `try/except` and log debug on failure
- keep generation path running even when chat-action calls fail

## Why
This preserves immediate user feedback during slower image-fetch flows and prevents transient Telegram chat-action errors from aborting AI response generation.

## Validation
- `python3 -m py_compile main.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebf270ed-5a2e-49b9-ab82-6c93cd6c596c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebf270ed-5a2e-49b9-ab82-6c93cd6c596c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI message generation reliability by gracefully handling typing indicator failures, preventing them from disrupting message processing.
  * Enhanced error logging for better debugging of chat action issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/gemini-bot/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->