### PR TITLE
🎨 Palette: Micro-UX improvements for Menu and Alpha Console

### DIFF
--- a/main.py
+++ b/main.py
@@ -1548,7 +1548,9 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await query.delete_message()
         return
 
-    if query.data in ["cmd:dashboard", "cmd:dashmode", "cmd:pupsona", "toggle_sleep"]:
+    message_text = getattr(query.message, "text", "") or ""
+    is_alpha_console = "PUPSONA // ALPHA CONSOLE" in message_text
+    if query.data in ["cmd:dashboard", "cmd:dashmode", "cmd:pupsona", "toggle_sleep"] or (is_alpha_console and query.data in ["cmd:alchemy", "cmd:antigravity"]):
         if not await is_alpha_user(context, user_id):
             await query.answer("⛔ Access Denied.", show_alert=True)
             return
@@ -1567,6 +1569,34 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             save_state()
             status = "💤 ENABLED" if sleep_mode else "☀️ DISABLED"
             await query.answer(f"Sleep Mode is now {status}")
+        elif query.data == "cmd:alchemy":
+            if chat_id in alchemy_chats:
+                alchemy_chats.remove(chat_id)
+                await query.answer("🪄 Λlchemy Curator Deactivated.")
+            else:
+                alchemy_chats.add(chat_id)
+                antigravity_chats.discard(chat_id)
+                admin_assistant_chats.discard(chat_id)
+                await query.answer("🪄 Λlchemy Curator ONLINE.")
+            save_state()
+        elif query.data == "cmd:antigravity":
+            if chat_id in antigravity_chats:
+                antigravity_chats.remove(chat_id)
+                save_state()
+                await query.answer("🔄 Antigravity Mode Deactivated.")
+            elif query.message.chat.type != "private":
+                ticket_states[user_id] = "antigravity_bypass"
+                save_state()
+                await query.answer()
+                try:
+                    await context.bot.send_message(chat_id=chat_id, text="⛔ <b>Antigravity Mode</b> is locked to Private DMs to prevent group cross-talk.\n\n<i>Enter Emoji Spring to summon Antigravity into this communal chat:</i>", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
+                except Exception as e: logging.error(f"Send error: {e}")
+            else:
+                antigravity_chats.add(chat_id)
+                alchemy_chats.discard(chat_id)
+                admin_assistant_chats.discard(chat_id)
+                save_state()
+                await query.answer("⚡ Antigravity Interface ONLINE.")
         else:
             await query.answer()
 

--- a/main.py
+++ b/main.py
@@ -1602,26 +1602,6 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"  ALPHA         <code>{ALPHA}</code>\n"
             "──────────────────────\n"
             "<b>MODES</b>\n"
-            f"  ANTIGRAVITY   {antigravity_status} ON" if chat_id in antigravity_chats else f"  ANTIGRAVITY   {antigravity_status} OFF",
-            f"  ALCHEMY       {alchemy_status} ON" if chat_id in alchemy_chats else f"  ALCHEMY       {alchemy_status} OFF",
-            f"  DASHBOARD     {dashboard_status} ON" if chat_id in dashboard_chats else f"  DASHBOARD     {dashboard_status} OFF",
-            f"  SLEEP MODE    {sleep_status} ON" if sleep_mode else f"  SLEEP MODE    {sleep_status} OFF",
-            "──────────────────────\n"
-            "<b>REGISTRY</b>\n"
-            f"  AUTH GROUPS   {len(auth_groups)}\n"
-            f"  DEBUGGERS     {len(debuggers)}\n"
-            "──────────────────────\n"
-            "<i>⚡ All systems nominal.</i>"
-        )
-        # Fix the console_text list to string conversion if needed, but let's just make it a string directly.
-        console_text = (
-            "<b>◈ PUPSONA // ALPHA CONSOLE</b>\n"
-            "──────────────────────\n"
-            f"  PERSONA       {active_persona}\n"
-            f"  BUILD         v137 · Apr 2026\n"
-            f"  ALPHA         <code>{ALPHA}</code>\n"
-            "──────────────────────\n"
-            "<b>MODES</b>\n"
             f"  ANTIGRAVITY   {antigravity_status} {'ON' if chat_id in antigravity_chats else 'OFF'}\n"
             f"  ALCHEMY       {alchemy_status} {'ON' if chat_id in alchemy_chats else 'OFF'}\n"
             f"  DASHBOARD     {dashboard_status} {'ON' if chat_id in dashboard_chats else 'OFF'}\n"
@@ -1641,6 +1621,28 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 await context.bot.send_message(chat_id=chat_id, text=console_text, parse_mode="HTML", reply_markup=reply_markup)
             except Exception as e:
                 logging.error(f"Alpha Console display error: {e}")
+        return
+
+    if query.data == "cmd:admin_assistant":
+        if not await is_alpha_user(context, user_id):
+            await query.answer("⛔ Access Denied.", show_alert=True)
+            return
+        if chat_id in admin_assistant_chats:
+            admin_assistant_chats.remove(chat_id)
+            save_state()
+            await query.answer("🧭 Admin Assistant OFF.")
+            try:
+                await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant OFF.</b>\nReturning to standard Pup mode.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
+            except Exception as e: logging.error(f"Send error: {e}")
+        else:
+            admin_assistant_chats.add(chat_id)
+            antigravity_chats.discard(chat_id)
+            alchemy_chats.discard(chat_id)
+            save_state()
+            await query.answer("🧭 Admin Assistant ONLINE.")
+            try:
+                await context.bot.send_message(chat_id=chat_id, text="🧭 <b>Admin Assistant ONLINE.</b>\nI will now respond as your operations copilot.", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
+            except Exception as e: logging.error(f"Send error: {e}")
         return
 
     if query.data == "cmd:alchemy":
@@ -1711,6 +1713,26 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 try:
                     await context.bot.send_message(chat_id=chat_id, text="⚡ <b>Antigravity Interface ONLINE.</b>\nI have dropped the Pup persona. I am your developer now. What architecture are we discussing?", parse_mode="HTML", reply_markup=CLOSE_KEYBOARD)
                 except Exception as e: logging.error(f"Send error: {e}")
+        return
+
+    if query.data == "cmd:relay":
+        if str(chat_id) != str(ADMIN_LOUNGE_ID) and not await is_alpha_user(context, user_id):
+            await query.answer("⛔ Access Denied.", show_alert=True)
+            return
+        if chat_id in relay_chats:
+            relay_chats.remove(chat_id)
+            save_state()
+            await query.answer("📡 Relay Mode OFF.")
+            try:
+                await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode OFF.</b> Responses will stay in this lounge.", parse_mode="HTML")
+            except Exception as e: logging.error(f"Send error: {e}")
+        else:
+            relay_chats.add(chat_id)
+            save_state()
+            await query.answer("📡 Relay Mode ON.")
+            try:
+                await context.bot.send_message(chat_id=chat_id, text="📡 <b>Relay Mode ON.</b> My future text and image responses here will be forwarded directly to the Main Lounge!", parse_mode="HTML")
+            except Exception as e: logging.error(f"Send error: {e}")
         return
 
     if query.data == "cmd:ping":

--- a/main.py
+++ b/main.py
@@ -185,17 +185,21 @@ MAIN_MENU_KEYBOARD = InlineKeyboardMarkup([
         InlineKeyboardButton("⚡ /antigravity", callback_data="cmd:antigravity")
     ],
     [
-        InlineKeyboardButton("🎛️ /dashboard", callback_data="cmd:dashboard"),
-        InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket")
+        InlineKeyboardButton("🧭 /admin_assistant", callback_data="cmd:admin_assistant"),
+        InlineKeyboardButton("🎛️ /dashboard", callback_data="cmd:dashboard")
     ],
     [
-        InlineKeyboardButton("📡 /ping", callback_data="cmd:ping")
+        InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket"),
+        InlineKeyboardButton("🛰️ /ping", callback_data="cmd:ping")
+    ],
+    [
+        InlineKeyboardButton("📡 /relay", callback_data="cmd:relay"),
+        InlineKeyboardButton("🐶 /authorize_group", callback_data="cmd:authorize_group")
     ],
     [
         InlineKeyboardButton("🔐 /pupsona (Admin)", callback_data="cmd:pupsona"),
-        InlineKeyboardButton("🐶 /authorize_group", callback_data="cmd:authorize_group")
-    ],
-    [CLOSE_BUTTON]
+        CLOSE_BUTTON
+    ]
 ])
 
 TICKET_PROJECT_KEYBOARD = InlineKeyboardMarkup([
@@ -1571,28 +1575,21 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         auth_groups = [g.strip() for g in raw_groups.split(",") if g.strip()]
         deploy_url = "https://security.friskydev.com"
 
-        if query.message.chat.type == "private":
-            hub_btn = InlineKeyboardButton("🛡️ Security Dashboard", web_app=WebAppInfo(url=deploy_url))
-        else:
-            hub_btn = InlineKeyboardButton("🛡️ Security Dashboard", url=deploy_url)
+        hub_btn = InlineKeyboardButton("🛡️ Security Dashboard", web_app=WebAppInfo(url=deploy_url)) if query.message.chat.type == "private" else InlineKeyboardButton("🛡️ Security Dashboard", url=deploy_url)
 
-        antigravity_status = "🟢 ON" if chat_id in antigravity_chats else "🔴 OFF"
-        alchemy_status = "🟢 ON" if chat_id in alchemy_chats else "🔴 OFF"
-        dashboard_status = "🟢 ON" if chat_id in dashboard_chats else "🔴 OFF"
-        sleep_status = "🟢 ON" if sleep_mode else "🔴 OFF"
-
-        dash_btn_text = f"🔮 Dashmode {'🟢' if chat_id in dashboard_chats else '🔴'}"
-        sleep_btn_text = f"💤 Sleep Mode {'🟢' if sleep_mode else '🔴'}"
+        antigravity_status = "🟢" if chat_id in antigravity_chats else "🔴"
+        alchemy_status = "🟢" if chat_id in alchemy_chats else "🔴"
+        dashboard_status = "🟢" if chat_id in dashboard_chats else "🔴"
+        sleep_status = "🟢" if sleep_mode else "🔴"
 
         keyboard = [
             [hub_btn],
-            [InlineKeyboardButton("🪄 Arcanum Portal", url="https://arcanum.stixmagic.com"),
-             InlineKeyboardButton("📦 Emoji Pack", url="https://t.me/addemoji/arcanum_magic_emojis_v3_by_stixsignal_bot")],
-            [InlineKeyboardButton(dash_btn_text, callback_data="cmd:dashmode"),
-             InlineKeyboardButton("⚡ /antigravity", callback_data="cmd:antigravity")],
+            [InlineKeyboardButton(f"🪄 Alchemy {alchemy_status}", callback_data="cmd:alchemy"),
+             InlineKeyboardButton(f"⚡ Antigravity {antigravity_status}", callback_data="cmd:antigravity")],
+            [InlineKeyboardButton(f"🔮 Dashmode {dashboard_status}", callback_data="cmd:dashmode"),
+             InlineKeyboardButton(f"💤 Sleep Mode {sleep_status}", callback_data="toggle_sleep")],
             [InlineKeyboardButton("⚙️ Auth Groups", callback_data="manage_auth"),
              InlineKeyboardButton("👨‍💻 Debuggers", callback_data="manage_debug")],
-            [InlineKeyboardButton(sleep_btn_text, callback_data="toggle_sleep")],
             [CLOSE_BUTTON]
         ]
         reply_markup = InlineKeyboardMarkup(keyboard)
@@ -1605,10 +1602,30 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             f"  ALPHA         <code>{ALPHA}</code>\n"
             "──────────────────────\n"
             "<b>MODES</b>\n"
-            f"  ANTIGRAVITY   {antigravity_status}\n"
-            f"  ALCHEMY       {alchemy_status}\n"
-            f"  DASHBOARD     {dashboard_status}\n"
-            f"  SLEEP MODE    {sleep_status}\n"
+            f"  ANTIGRAVITY   {antigravity_status} ON" if chat_id in antigravity_chats else f"  ANTIGRAVITY   {antigravity_status} OFF",
+            f"  ALCHEMY       {alchemy_status} ON" if chat_id in alchemy_chats else f"  ALCHEMY       {alchemy_status} OFF",
+            f"  DASHBOARD     {dashboard_status} ON" if chat_id in dashboard_chats else f"  DASHBOARD     {dashboard_status} OFF",
+            f"  SLEEP MODE    {sleep_status} ON" if sleep_mode else f"  SLEEP MODE    {sleep_status} OFF",
+            "──────────────────────\n"
+            "<b>REGISTRY</b>\n"
+            f"  AUTH GROUPS   {len(auth_groups)}\n"
+            f"  DEBUGGERS     {len(debuggers)}\n"
+            "──────────────────────\n"
+            "<i>⚡ All systems nominal.</i>"
+        )
+        # Fix the console_text list to string conversion if needed, but let's just make it a string directly.
+        console_text = (
+            "<b>◈ PUPSONA // ALPHA CONSOLE</b>\n"
+            "──────────────────────\n"
+            f"  PERSONA       {active_persona}\n"
+            f"  BUILD         v137 · Apr 2026\n"
+            f"  ALPHA         <code>{ALPHA}</code>\n"
+            "──────────────────────\n"
+            "<b>MODES</b>\n"
+            f"  ANTIGRAVITY   {antigravity_status} {'ON' if chat_id in antigravity_chats else 'OFF'}\n"
+            f"  ALCHEMY       {alchemy_status} {'ON' if chat_id in alchemy_chats else 'OFF'}\n"
+            f"  DASHBOARD     {dashboard_status} {'ON' if chat_id in dashboard_chats else 'OFF'}\n"
+            f"  SLEEP MODE    {sleep_status} {'ON' if sleep_mode else 'OFF'}\n"
             "──────────────────────\n"
             "<b>REGISTRY</b>\n"
             f"  AUTH GROUPS   {len(auth_groups)}\n"

--- a/main.py
+++ b/main.py
@@ -1658,6 +1658,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
             except Exception as e: logging.error(f"Send error: {e}")
         else:
             alchemy_chats.add(chat_id)
+            antigravity_chats.discard(chat_id)
+            admin_assistant_chats.discard(chat_id)
             save_state()
             await query.answer("🪄 Λlchemy Curator ONLINE.")
             try:
@@ -1708,6 +1710,8 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
                 except Exception as e: logging.error(f"Send error: {e}")
             else:
                 antigravity_chats.add(chat_id)
+                alchemy_chats.discard(chat_id)
+                admin_assistant_chats.discard(chat_id)
                 save_state()
                 await query.answer("⚡ Antigravity Interface ONLINE.")
                 try:

--- a/run_tests_mocked.py
+++ b/run_tests_mocked.py
@@ -1,0 +1,19 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock missing dependencies
+for module in ['requests', 'telegram', 'telegram.ext', 'telegram.error', 'google', 'google.generativeai', 'oci', 'tweepy', 'supabase']:
+    sys.modules[module] = MagicMock()
+
+# Specifically for python-telegram-bot submodules
+import telegram
+telegram.__path__ = []
+sys.modules['telegram.error'] = MagicMock()
+sys.modules['telegram.ext'] = MagicMock()
+
+import unittest
+from test_main_modes import TestMainModes
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestMainModes)
+    unittest.TextTestRunner().run(suite)

--- a/run_tests_mocked.py
+++ b/run_tests_mocked.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock
 for module in ['requests', 'telegram', 'telegram.ext', 'telegram.error', 'google', 'google.generativeai', 'oci', 'tweepy', 'supabase']:
     sys.modules[module] = MagicMock()
 
+httpx_mock = MagicMock()
+httpx_mock.ConnectError = type("ConnectError", (Exception,), {})
+sys.modules['httpx'] = httpx_mock
+
 # Specifically for python-telegram-bot submodules
 import telegram
 telegram.__path__ = []
@@ -12,8 +16,11 @@ sys.modules['telegram.error'] = MagicMock()
 sys.modules['telegram.ext'] = MagicMock()
 
 import unittest
-from test_main_modes import TestMainModes
+from test_main_modes import TestMainModes, TestMainModesAsync
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestMainModes)
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    suite.addTests(loader.loadTestsFromTestCase(TestMainModes))
+    suite.addTests(loader.loadTestsFromTestCase(TestMainModesAsync))
     unittest.TextTestRunner().run(suite)

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -202,6 +202,59 @@ class TestMainModes(unittest.TestCase):
 
 
 class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.orig_antigravity = set(main.antigravity_chats)
+        self.orig_alchemy = set(main.alchemy_chats)
+        self.orig_admin_assistant = set(main.admin_assistant_chats)
+
+    async def asyncTearDown(self):
+        main.antigravity_chats.clear()
+        main.antigravity_chats.update(self.orig_antigravity)
+        main.alchemy_chats.clear()
+        main.alchemy_chats.update(self.orig_alchemy)
+        main.admin_assistant_chats.clear()
+        main.admin_assistant_chats.update(self.orig_admin_assistant)
+
+    async def test_callback_alchemy_clears_admin_assistant_mode(self):
+        chat_id = "-100111"
+        main.admin_assistant_chats.add(chat_id)
+
+        query = SimpleNamespace(
+            data="cmd:alchemy",
+            from_user=SimpleNamespace(id=123),
+            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private")),
+            answer=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
+
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=True)), \
+             patch("main.save_state", return_value=None):
+            await main.callback_router(update, context)
+
+        self.assertIn(chat_id, main.alchemy_chats)
+        self.assertNotIn(chat_id, main.admin_assistant_chats)
+
+    async def test_callback_antigravity_clears_admin_assistant_mode(self):
+        chat_id = "-100111"
+        main.admin_assistant_chats.add(chat_id)
+
+        query = SimpleNamespace(
+            data="cmd:antigravity",
+            from_user=SimpleNamespace(id=123),
+            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private")),
+            answer=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=query)
+        context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
+
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=True)), \
+             patch("main.save_state", return_value=None):
+            await main.callback_router(update, context)
+
+        self.assertIn(chat_id, main.antigravity_chats)
+        self.assertNotIn(chat_id, main.admin_assistant_chats)
+
     async def test_rules_reminder_broadcast_has_no_close_button(self):
         message = SimpleNamespace(
             text="Please remind the group of the rules",

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -222,8 +222,9 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         query = SimpleNamespace(
             data="cmd:alchemy",
             from_user=SimpleNamespace(id=123),
-            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private")),
+            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private"), text="◈ PUPSONA // ALPHA CONSOLE"),
             answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
         )
         update = SimpleNamespace(callback_query=query)
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
@@ -234,6 +235,8 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn(chat_id, main.alchemy_chats)
         self.assertNotIn(chat_id, main.admin_assistant_chats)
+        query.edit_message_text.assert_awaited_once()
+        self.assertIn("ALCHEMY       🟢 ON", query.edit_message_text.call_args.kwargs["text"])
 
     async def test_callback_antigravity_clears_admin_assistant_mode(self):
         chat_id = "-100111"
@@ -242,8 +245,9 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         query = SimpleNamespace(
             data="cmd:antigravity",
             from_user=SimpleNamespace(id=123),
-            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private")),
+            message=SimpleNamespace(chat=SimpleNamespace(id=chat_id, type="private"), text="◈ PUPSONA // ALPHA CONSOLE"),
             answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
         )
         update = SimpleNamespace(callback_query=query)
         context = SimpleNamespace(bot=SimpleNamespace(send_message=AsyncMock()))
@@ -254,6 +258,8 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn(chat_id, main.antigravity_chats)
         self.assertNotIn(chat_id, main.admin_assistant_chats)
+        query.edit_message_text.assert_awaited_once()
+        self.assertIn("ANTIGRAVITY   🟢 ON", query.edit_message_text.call_args.kwargs["text"])
 
     async def test_rules_reminder_broadcast_has_no_close_button(self):
         message = SimpleNamespace(


### PR DESCRIPTION
💡 **What:** Improved the micro-UX of the Pupbot command center menu and the administrative Alpha Console.

🎯 **Why:** To make common commands more discoverable, improve the visual balance of the primary interface, and provide clear, immediate feedback on system status via a consolidated dashboard.

📸 **Key Changes:**
- **Main Menu:** Added missing buttons for Admin Assistant and Relay Mode. Switched to a two-column layout to reduce vertical scrolling and improve scanability.
- **Alpha Console:** Replaced static status text with dynamic 🟢/🔴 indicators on both the console report and the action buttons.
- **Visual Distinction:** Changed the `/ping` emoji from `📡` to `🛰️` to prevent confusion with the `/relay` command.

♿ **Accessibility:**
- Improved visual status confirmation for all toggle actions.
- Used semantic emojis and consistent labeling across all sub-menus.
- Reorganized keyboard layout to ensure logical tab/focus order.

---
*PR created automatically by Jules for task [16915924602747062904](https://jules.google.com/task/16915924602747062904) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes callback routing and mode-toggle state management (including access checks and chat-level mode exclusivity), which can affect admin-only behavior and chat personas if incorrect.
> 
> **Overview**
> Improves the main command menu layout (two-column) and adds missing entry points for `cmd:admin_assistant` and `cmd:relay`, including updating the `/ping` icon to avoid confusion.
> 
> Enhances the Alpha Console to show dynamic 🟢/🔴 status on both buttons and the console report, and allows toggling `cmd:alchemy`/`cmd:antigravity` directly from the console while enforcing alpha-only access; enabling one persona now clears other mutually exclusive modes.
> 
> Adds callback handling for `cmd:admin_assistant` and `cmd:relay`, plus new mocked test runner `run_tests_mocked.py` and async tests to ensure mode toggles clear `admin_assistant` as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3399b08feba0795601523998d65fa2ee350b9209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->