### PR TITLE
🎨 Palette: Unified context-aware menus with status indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,7 @@
 ## 2026-05-15 - [Real-time Status Visualization]
 **Learning:** In interactive dashboards, users need immediate visual confirmation of state changes. Consolidating toggle logic within the dashboard's render loop and adding 🟢/🔴 status indicators to both labels and buttons provides "Visibility of System Status" and makes the interface feel more responsive.
 **Action:** Use 🟢/🔴 indicators for boolean states in menus and ensure toggle actions trigger an immediate UI refresh of the parent menu.
+
+## 2026-05-17 - [Unified Context-Aware Menus with Status Indicators]
+**Learning:** For bots with multiple toggleable modes, providing immediate visibility of system status in the main menu reduces cognitive load. Centralizing menu generation into a single helper ensure consistency across command-based and button-based entry points.
+**Action:** Use a unified `build_main_menu` helper to inject 🟢/🔴 status indicators into buttons and prepend mode-specific help text dynamically.

--- a/main.py
+++ b/main.py
@@ -179,28 +179,6 @@ admin_owner_last_refresh = 0.0
 CLOSE_BUTTON = InlineKeyboardButton("🗑️ Close", callback_data="close_message")
 CLOSE_KEYBOARD = InlineKeyboardMarkup([[CLOSE_BUTTON]])
 
-MAIN_MENU_KEYBOARD = InlineKeyboardMarkup([
-    [
-        InlineKeyboardButton("🪄 /alchemy", callback_data="cmd:alchemy"),
-        InlineKeyboardButton("⚡ /antigravity", callback_data="cmd:antigravity")
-    ],
-    [
-        InlineKeyboardButton("🧭 /admin_assistant", callback_data="cmd:admin_assistant"),
-        InlineKeyboardButton("🎛️ /dashboard", callback_data="cmd:dashboard")
-    ],
-    [
-        InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket"),
-        InlineKeyboardButton("🛰️ /ping", callback_data="cmd:ping")
-    ],
-    [
-        InlineKeyboardButton("📡 /relay", callback_data="cmd:relay"),
-        InlineKeyboardButton("🐶 /authorize_group", callback_data="cmd:authorize_group")
-    ],
-    [
-        InlineKeyboardButton("🔐 /pupsona (Admin)", callback_data="cmd:pupsona"),
-        CLOSE_BUTTON
-    ]
-])
 
 TICKET_PROJECT_KEYBOARD = InlineKeyboardMarkup([
     [InlineKeyboardButton("Clipsflow", callback_data="ticket_proj:ClipFLOW"),
@@ -355,6 +333,47 @@ def get_effective_mode(chat_id):
     if mode_name in {"antigravity", "alchemy", "admin_assistant"}:
         return mode_name
     return "puppy"
+
+
+def build_main_menu(chat_id):
+    chat_id = _safe_chat_id(chat_id)
+    effective_mode = get_effective_mode(chat_id)
+
+    active_menu = MENU_TEXT
+    if effective_mode == "antigravity":
+        active_menu = f"{ANTIGRAVITY_MENU_TEXT}\n\n{MENU_TEXT}"
+    elif effective_mode == "alchemy":
+        active_menu = f"{ALCHEMY_MENU_TEXT}\n\n{MENU_TEXT}"
+    elif effective_mode == "admin_assistant":
+        active_menu = f"{ADMIN_ASSISTANT_MENU_TEXT}\n\n{MENU_TEXT}"
+
+    antigravity_status = "🟢" if chat_id in antigravity_chats else "🔴"
+    alchemy_status = "🟢" if chat_id in alchemy_chats else "🔴"
+    admin_assistant_status = "🟢" if chat_id in admin_assistant_chats else "🔴"
+
+    keyboard = [
+        [
+            InlineKeyboardButton(f"🪄 Alchemy {alchemy_status}", callback_data="cmd:alchemy"),
+            InlineKeyboardButton(f"⚡ Antigravity {antigravity_status}", callback_data="cmd:antigravity")
+        ],
+        [
+            InlineKeyboardButton(f"🧭 Admin Asst {admin_assistant_status}", callback_data="cmd:admin_assistant"),
+            InlineKeyboardButton("🎛️ Dashboard", callback_data="cmd:dashboard")
+        ],
+        [
+            InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket"),
+            InlineKeyboardButton("🛰️ /ping", callback_data="cmd:ping")
+        ],
+        [
+            InlineKeyboardButton("📡 /relay", callback_data="cmd:relay"),
+            InlineKeyboardButton("🐶 /auth_group", callback_data="cmd:authorize_group")
+        ],
+        [
+            InlineKeyboardButton("🔐 /pupsona (Admin)", callback_data="cmd:pupsona"),
+            CLOSE_BUTTON
+        ]
+    ]
+    return active_menu, InlineKeyboardMarkup(keyboard)
 
 
 def is_admin_lounge_chat(chat_id):
@@ -719,12 +738,14 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
+            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+            active_menu, reply_markup = build_main_menu(chat_id)
             try:
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
-                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=active_menu, parse_mode="HTML", reply_markup=reply_markup)
             except Exception as e:
                 logging.error("Menu formatting crash", exc_info=True)
-                await context.bot.send_message(chat_id=chat_id, text=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+                await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=reply_markup)
             return
 
         # Command to add debuggers
@@ -1857,20 +1878,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if query.data == "show_menu":
         await query.answer()
-        active_menu = MENU_TEXT
-        effective_mode = get_effective_mode(chat_id)
-
-        if effective_mode == "antigravity":
-            active_menu = f"{ANTIGRAVITY_MENU_TEXT}\n\n{MENU_TEXT}"
-        elif effective_mode == "alchemy":
-            active_menu = f"{ALCHEMY_MENU_TEXT}\n\n{MENU_TEXT}"
-        elif effective_mode == "admin_assistant":
-            active_menu = f"{ADMIN_ASSISTANT_MENU_TEXT}\n\n{MENU_TEXT}"
-
+        active_menu, reply_markup = build_main_menu(chat_id)
         try:
-            await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+            await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=reply_markup)
         except Exception:
-            await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+            await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=reply_markup)
         return
 
     if query.data == "ping_back":

--- a/main.py
+++ b/main.py
@@ -149,6 +149,9 @@ Operational tools for Alphas:
 
 <i>Type /admin_assistant to toggle off.</i>"""
 
+TELEGRAM_ANIMATION_CAPTION_LIMIT = 1024
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
 import db
 
 db.init_db()
@@ -374,6 +377,16 @@ def build_main_menu(chat_id):
         ]
     ]
     return active_menu, InlineKeyboardMarkup(keyboard)
+
+
+def _html_text_length(text):
+    return len(html.unescape(_HTML_TAG_RE.sub("", text)))
+
+
+def _animation_menu_caption(menu_text):
+    if _html_text_length(menu_text) <= TELEGRAM_ANIMATION_CAPTION_LIMIT:
+        return menu_text
+    return MENU_TEXT
 
 
 def is_admin_lounge_chat(chat_id):
@@ -740,9 +753,10 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if text_lower in ["/start", "/menu", "/help"]:
             await context.bot.send_chat_action(chat_id=chat_id, action="typing")
             active_menu, reply_markup = build_main_menu(chat_id)
+            animation_caption = _animation_menu_caption(active_menu)
             try:
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
-                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=active_menu, parse_mode="HTML", reply_markup=reply_markup)
+                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=animation_caption, parse_mode="HTML", reply_markup=reply_markup)
             except Exception as e:
                 logging.error("Menu formatting crash", exc_info=True)
                 await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=reply_markup)

--- a/main.py
+++ b/main.py
@@ -751,7 +751,10 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
-            await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+            try:
+                await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+            except Exception as e:
+                logging.debug(f"Ignored error: {e}")
             active_menu, reply_markup = build_main_menu(chat_id)
             animation_caption = _animation_menu_caption(active_menu)
             try:

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -347,6 +347,42 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         self.assertLessEqual(_html_text_length(caption), 1024)
         context.bot.send_message.assert_not_awaited()
 
+    async def test_menu_still_displays_when_chat_action_fails(self):
+        chat_id = "-100111"
+        message = SimpleNamespace(
+            text="/menu",
+            caption=None,
+            new_chat_members=None,
+            from_user=SimpleNamespace(id=123),
+            reply_to_message=None,
+            chat=SimpleNamespace(type="private"),
+        )
+        update = SimpleNamespace(
+            effective_message=message,
+            effective_user=SimpleNamespace(id=123),
+            effective_chat=SimpleNamespace(id=chat_id),
+            message=message,
+        )
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                send_chat_action=AsyncMock(side_effect=RuntimeError("typing failed")),
+                send_animation=AsyncMock(),
+                send_message=AsyncMock(),
+            )
+        )
+
+        raised = None
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=False)), \
+             patch("builtins.open", return_value=io.BytesIO(b"gif")):
+            try:
+                await main.lounge_host(update, context)
+            except RuntimeError as exc:
+                raised = exc
+
+        self.assertIsNone(raised)
+        context.bot.send_animation.assert_awaited_once()
+        context.bot.send_message.assert_not_awaited()
+
     async def test_refresh_dynamic_alpha_ids_includes_admins(self):
         original_admin_lounge_id = main.ADMIN_LOUNGE_ID
         original_dynamic_alpha_ids = set(main.dynamic_alpha_ids)

--- a/test_main_modes.py
+++ b/test_main_modes.py
@@ -1,10 +1,30 @@
 import unittest
+import io
 import os
+from html.parser import HTMLParser
 from types import SimpleNamespace
 from unittest.mock import patch
 from unittest.mock import AsyncMock
 
 import main
+
+
+class _HtmlTextLengthParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.parts = []
+
+    def handle_data(self, data):
+        self.parts.append(data)
+
+    def length(self):
+        return len("".join(self.parts))
+
+
+def _html_text_length(text):
+    parser = _HtmlTextLengthParser()
+    parser.feed(text)
+    return parser.length()
 
 
 class TestMainModes(unittest.TestCase):
@@ -292,6 +312,40 @@ class TestMainModesAsync(unittest.IsolatedAsyncioTestCase):
         broadcast_call = context.bot.send_message.call_args_list[0]
         self.assertEqual(broadcast_call.kwargs["chat_id"], "-200")
         self.assertNotIn("reply_markup", broadcast_call.kwargs)
+
+    async def test_menu_animation_caption_stays_within_telegram_limit_for_active_mode(self):
+        chat_id = "-100111"
+        main.antigravity_chats.add(chat_id)
+        message = SimpleNamespace(
+            text="/menu",
+            caption=None,
+            new_chat_members=None,
+            from_user=SimpleNamespace(id=123),
+            reply_to_message=None,
+            chat=SimpleNamespace(type="private"),
+        )
+        update = SimpleNamespace(
+            effective_message=message,
+            effective_user=SimpleNamespace(id=123),
+            effective_chat=SimpleNamespace(id=chat_id),
+            message=message,
+        )
+        context = SimpleNamespace(
+            bot=SimpleNamespace(
+                send_chat_action=AsyncMock(),
+                send_animation=AsyncMock(),
+                send_message=AsyncMock(),
+            )
+        )
+
+        with patch("main.is_alpha_user", new=AsyncMock(return_value=False)), \
+             patch("builtins.open", return_value=io.BytesIO(b"gif")):
+            await main.lounge_host(update, context)
+
+        context.bot.send_animation.assert_awaited_once()
+        caption = context.bot.send_animation.call_args.kwargs["caption"]
+        self.assertLessEqual(_html_text_length(caption), 1024)
+        context.bot.send_message.assert_not_awaited()
 
     async def test_refresh_dynamic_alpha_ids_includes_admins(self):
         original_admin_lounge_id = main.ADMIN_LOUNGE_ID


### PR DESCRIPTION
This PR implements a micro-UX improvement by unifying the main menu generation and adding real-time status indicators.

💡 **What:** 
- Centralized the Command Center's text and keyboard logic into a `build_main_menu` function.
- Injected dynamic 🟢/🔴 indicators into the Alchemy, Antigravity, and Admin Assistant buttons.
- Integrated `context.bot.send_chat_action(action='typing')` for all menu-related slash commands.

🎯 **Why:** 
- Users previously had no way of knowing which persona mode was active in a chat without trying to speak to the bot or digging into the Alpha Console.
- Command-based entry (/menu) was inconsistent with button-based navigation (it lacked the mode-specific headers).
- The "typing" indicator reduces perceived latency and confirms the bot is responding.

♿ **Accessibility:**
- Improved "Visibility of System Status" (Nielsen Heuristic) by providing clear visual cues for active states.
- Ensured consistent interaction patterns regardless of how the user accesses the menu.

---
*PR created automatically by Jules for task [8329394175229623932](https://jules.google.com/task/8329394175229623932) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX refactor that centralizes menu generation and adds minor Telegram API calls; main potential issues are mismatched callback labels/markup and caption-length edge cases.
> 
> **Overview**
> **Unifies main menu generation** by replacing the static `MAIN_MENU_KEYBOARD` and duplicated header logic with a single `build_main_menu(chat_id)` helper that returns both the context-aware menu text and keyboard.
> 
> **Adds real-time status indicators** (🟢/🔴) to the Alchemy/Antigravity/Admin Assistant buttons and ensures `/start`/`/menu`/`/help` and the `show_menu` callback render the same mode-prefixed menu.
> 
> **Hardens menu delivery** by sending a best-effort `send_chat_action('typing')` before menu responses and by enforcing Telegram’s 1024 animation caption limit via `_animation_menu_caption`, with new tests covering caption length and chat-action failure fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d6dff0780d3d63ae523600b4d8fedd1512a8e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->