### PR TITLE
🎨 Palette: Dynamic status indicators for main menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,28 +179,6 @@ admin_owner_last_refresh = 0.0
 CLOSE_BUTTON = InlineKeyboardButton("🗑️ Close", callback_data="close_message")
 CLOSE_KEYBOARD = InlineKeyboardMarkup([[CLOSE_BUTTON]])
 
-MAIN_MENU_KEYBOARD = InlineKeyboardMarkup([
-    [
-        InlineKeyboardButton("🪄 /alchemy", callback_data="cmd:alchemy"),
-        InlineKeyboardButton("⚡ /antigravity", callback_data="cmd:antigravity")
-    ],
-    [
-        InlineKeyboardButton("🧭 /admin_assistant", callback_data="cmd:admin_assistant"),
-        InlineKeyboardButton("🎛️ /dashboard", callback_data="cmd:dashboard")
-    ],
-    [
-        InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket"),
-        InlineKeyboardButton("🛰️ /ping", callback_data="cmd:ping")
-    ],
-    [
-        InlineKeyboardButton("📡 /relay", callback_data="cmd:relay"),
-        InlineKeyboardButton("🐶 /authorize_group", callback_data="cmd:authorize_group")
-    ],
-    [
-        InlineKeyboardButton("🔐 /pupsona (Admin)", callback_data="cmd:pupsona"),
-        CLOSE_BUTTON
-    ]
-])
 
 TICKET_PROJECT_KEYBOARD = InlineKeyboardMarkup([
     [InlineKeyboardButton("Clipsflow", callback_data="ticket_proj:ClipFLOW"),
@@ -355,6 +333,38 @@ def get_effective_mode(chat_id):
     if mode_name in {"antigravity", "alchemy", "admin_assistant"}:
         return mode_name
     return "puppy"
+
+
+def build_menu(chat_id):
+    cid = str(chat_id)
+    alchemy_status = "🟢" if cid in alchemy_chats else "🔴"
+    antigravity_status = "🟢" if cid in antigravity_chats else "🔴"
+    admin_assistant_status = "🟢" if cid in admin_assistant_chats else "🔴"
+    dashboard_status = "🟢" if cid in dashboard_chats else "🔴"
+    relay_status = "🟢" if cid in relay_chats else "🔴"
+
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton(f"🪄 Alchemy {alchemy_status}", callback_data="cmd:alchemy"),
+            InlineKeyboardButton(f"⚡ Antigravity {antigravity_status}", callback_data="cmd:antigravity")
+        ],
+        [
+            InlineKeyboardButton(f"🧭 Admin Asst {admin_assistant_status}", callback_data="cmd:admin_assistant"),
+            InlineKeyboardButton(f"🎛️ Dashboard {dashboard_status}", callback_data="cmd:dashboard")
+        ],
+        [
+            InlineKeyboardButton("👔 /ticket", callback_data="cmd:ticket"),
+            InlineKeyboardButton("🛰️ /ping", callback_data="cmd:ping")
+        ],
+        [
+            InlineKeyboardButton(f"📡 Relay {relay_status}", callback_data="cmd:relay"),
+            InlineKeyboardButton("🐶 /authorize_group", callback_data="cmd:authorize_group")
+        ],
+        [
+            InlineKeyboardButton("🔐 /pupsona (Admin)", callback_data="cmd:pupsona"),
+            CLOSE_BUTTON
+        ]
+    ])
 
 
 def is_admin_lounge_chat(chat_id):
@@ -719,12 +729,13 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text_lower = text.lower()
         
         if text_lower in ["/start", "/menu", "/help"]:
+            reply_markup = build_menu(chat_id)
             try:
                 with open(os.path.join(os.path.dirname(__file__), "assets/entrance_animation.gif"), "rb") as gif:
-                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+                    await context.bot.send_animation(chat_id=chat_id, animation=gif, caption=MENU_TEXT, parse_mode="HTML", reply_markup=reply_markup)
             except Exception as e:
                 logging.error("Menu formatting crash", exc_info=True)
-                await context.bot.send_message(chat_id=chat_id, text=MENU_TEXT, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+                await context.bot.send_message(chat_id=chat_id, text=MENU_TEXT, parse_mode="HTML", reply_markup=reply_markup)
             return
 
         # Command to add debuggers
@@ -1867,10 +1878,11 @@ async def callback_router(update: Update, context: ContextTypes.DEFAULT_TYPE):
         elif effective_mode == "admin_assistant":
             active_menu = f"{ADMIN_ASSISTANT_MENU_TEXT}\n\n{MENU_TEXT}"
 
+        reply_markup = build_menu(chat_id)
         try:
-            await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+            await query.edit_message_text(active_menu, parse_mode="HTML", reply_markup=reply_markup)
         except Exception:
-            await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=MAIN_MENU_KEYBOARD)
+            await context.bot.send_message(chat_id=chat_id, text=active_menu, parse_mode="HTML", reply_markup=reply_markup)
         return
 
     if query.data == "ping_back":


### PR DESCRIPTION
This PR implements a micro-UX enhancement for the Pupbot command center.

### 💡 What
Converts the static main menu into a dynamic interface that reflects the current activation status of various bot modes (Alchemy, Antigravity, Admin Assistant, etc.) using 🟢/🔴 indicators.

### 🎯 Why
Previously, users had to enter specific sub-menus or the Alpha Console to see which modes were active for their current chat. This change provides immediate, at-a-glance feedback in the main menu, reducing cognitive load and improving the "Visibility of System Status" (Nielsen Heuristic #1).

### ♿ Accessibility & UX
- **Visual Feedback:** Immediate confirmation of mode state.
- **Mobile Optimization:** Shortened "Admin Assistant" to "Admin Asst" to ensure status indicators don't cause button text to wrap or truncate on smaller screens.
- **Consistency:** Ensures the menu always shows the truth, whether triggered via command or "Back" button.

### 🛠️ Technical Changes
- Defined `build_menu(chat_id)` helper.
- Removed static `MAIN_MENU_KEYBOARD`.
- Updated `lounge_host` and `callback_router` to use the dynamic builder.

---
*PR created automatically by Jules for task [3877703081073692466](https://jules.google.com/task/3877703081073692466) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX-only change that replaces a static inline keyboard with a dynamically generated one; main risk is minor UI/logic inconsistencies if chat_id typing/string normalization differs from the stored chat sets.
> 
> **Overview**
> The main command-center menu is now generated per chat via `build_menu(chat_id)`, adding 🟢/🔴 indicators for whether `alchemy`, `antigravity`, `admin_assistant`, `dashboard`, and `relay` are active, and shortening the Admin Assistant label to *Admin Asst*.
> 
> All entry points that render the menu (`/start`/`/menu`/`/help` and the `show_menu` callback) were updated to use the new dynamic builder, and the old static `MAIN_MENU_KEYBOARD` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d851535084f29426c0ab77466e7717d9426d300a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->