### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Resource Exhaustion via Input Length Limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -698,7 +698,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
     # 1. RECORD NEW MEMBERS AND WHO INVITED THEM
     if update.message and update.message.new_chat_members:
         inviter = update.message.from_user
-        inviter_name = inviter.username or inviter.first_name or "Unknown"
+        # Enforce length limit to prevent potential resource exhaustion or UI breakage
+        inviter_name = (inviter.username or inviter.first_name or "Unknown")[:100]
         for member in update.message.new_chat_members:
             if inviter.id != member.id:
                 invitations[str(member.id)] = inviter_name
@@ -1362,7 +1363,8 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         should_reply = False
         
     if should_reply and has_text_or_photo:
-        user_text = update.message.text or update.message.caption or ""
+        # Enforce length limit to mitigate resource exhaustion/DoS risks
+        user_text = (update.message.text or update.message.caption or "")[:4000]
         
         # We explicitly skip slash commands meant for logic interception above so the bot doesn't reply.
         if user_text.startswith("/") and not user_text.startswith("/pup"):

--- a/main.py
+++ b/main.py
@@ -1347,7 +1347,9 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         return
                 
     # 3. CONVERSATIONAL LOGIC
-    text_lower = (update.message.text or update.message.caption or "").lower()
+    # Enforce length limit before trigger detection so prompts and triggers use the same text.
+    user_text = (update.message.text or update.message.caption or "")[:4000]
+    text_lower = user_text.lower()
     is_reply_to_bot = update.message.reply_to_message and update.message.reply_to_message.from_user.id == context.bot.id
     bot_mentioned = "pupbot" in text_lower or "pup" in text_lower or context.bot.username.lower() in text_lower
     is_private = update.message.chat.type == "private"
@@ -1363,9 +1365,6 @@ async def lounge_host(update: Update, context: ContextTypes.DEFAULT_TYPE):
         should_reply = False
         
     if should_reply and has_text_or_photo:
-        # Enforce length limit to mitigate resource exhaustion/DoS risks
-        user_text = (update.message.text or update.message.caption or "")[:4000]
-        
         # We explicitly skip slash commands meant for logic interception above so the bot doesn't reply.
         if user_text.startswith("/") and not user_text.startswith("/pup"):
             return

--- a/test_security_hardening.py
+++ b/test_security_hardening.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import sys
+import types
 import html
 from types import SimpleNamespace
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -125,6 +127,44 @@ class TestSecurityHardening(unittest.IsolatedAsyncioTestCase):
         calls = [call.kwargs.get('chat_id') for call in context.bot.send_message.call_args_list]
         self.assertIn("group_123", calls)
         self.assertIn(user_id, calls)
+
+    async def test_late_mention_after_truncation_limit_does_not_trigger_reply(self):
+        mock_msg = AsyncMock()
+        mock_msg.text = ("a" * 4000) + " pupbot?"
+        mock_msg.caption = None
+        mock_msg.photo = None
+        mock_msg.new_chat_members = None
+        mock_msg.reply_to_message = None
+        mock_msg.chat.type = "supergroup"
+        mock_msg.from_user.id = 12345
+        mock_msg.from_user.first_name = "User"
+
+        update = MagicMock()
+        update.message = mock_msg
+        update.effective_message = mock_msg
+        update.effective_user = mock_msg.from_user
+        update.effective_chat.id = 67890
+
+        context = MagicMock()
+        context.bot.id = 999
+        context.bot.username = "Geminipupbot"
+        context.bot.send_chat_action = AsyncMock()
+
+        fake_google = types.ModuleType("google")
+        fake_genai = types.ModuleType("google.generativeai")
+        fake_genai.configure = MagicMock()
+        fake_model = SimpleNamespace(
+            generate_content_async=AsyncMock(return_value=SimpleNamespace(text="response"))
+        )
+        fake_genai.GenerativeModel = MagicMock(return_value=fake_model)
+        fake_google.generativeai = fake_genai
+
+        with patch('main.is_alpha_user', new=AsyncMock(return_value=False)), \
+             patch.dict(sys.modules, {"google": fake_google, "google.generativeai": fake_genai}), \
+             patch('main.push_processed_response', new=AsyncMock()):
+            await main.lounge_host(update, context)
+
+        fake_genai.GenerativeModel.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I have implemented input length limits in `main.py` to protect the bot against resource exhaustion and potential Denial of Service (DoS) attacks. Specifically, I added a 4000-character limit to the conversational `user_text` and a 100-character limit to `inviter_name` metadata. These changes ensure that the application remains stable when handling unexpectedly large inputs, without impacting legitimate user interactions. All tests passed, and the changes have been verified for syntax and logic correctness.

---
*PR created automatically by Jules for task [15331550210513692072](https://jules.google.com/task/15331550210513692072) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive truncation changes plus a unit test; main behavior change is that mentions beyond 4k chars no longer trigger bot replies.
> 
> **Overview**
> Adds *input length hardening* in `main.py` by truncating `inviter_name` to 100 chars when recording invitations and truncating conversational `user_text` to 4000 chars **before** mention/trigger detection and prompt construction.
> 
> Extends `test_security_hardening.py` with a regression test ensuring a bot mention occurring after the 4000-char cutoff does not invoke the Gemini model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f08d19ae8fe4eaff28e460d7dfc894b54ac761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->